### PR TITLE
Add cloud image ID as a CLI option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ osd-network-verifier
 
 # ide
 .vscode/
+
+# Ignore temporary *.swp files
+*.swp

--- a/cmd/egress/cmd.go
+++ b/cmd/egress/cmd.go
@@ -11,6 +11,9 @@ import (
 )
 
 func NewCmdValidateEgress(streams genericclioptions.IOStreams) *cobra.Command {
+	var vpcSubnetID string
+	var cloudImageID string
+
 	validateEgressCmd := &cobra.Command{
 		Use: "egress",
 		Run: func(cmd *cobra.Command, args []string) {
@@ -24,9 +27,8 @@ func NewCmdValidateEgress(streams genericclioptions.IOStreams) *cobra.Command {
 			case caller == configv1.GCPPlatformType:
 				cli = cloudclient.GetClientFor(configv1.GCPPlatformType)
 			}
-			subnetid, _ := cmd.Flags().GetString("subnet-id")
 
-			err := cli.ValidateEgress(context.TODO(), subnetid)
+			err := cli.ValidateEgress(context.TODO(), vpcSubnetID, cloudImageID)
 
 			if err != nil {
 				streams.ErrOut.Write([]byte(err.Error()))
@@ -38,8 +40,10 @@ func NewCmdValidateEgress(streams genericclioptions.IOStreams) *cobra.Command {
 		},
 	}
 
-	validateEgressCmd.Flags().StringP("subnet-id", "", "", "ID of the source subnet")
+	validateEgressCmd.Flags().StringVar(&vpcSubnetID, "subnet-id", "", "ID of the source subnet")
+	validateEgressCmd.Flags().StringVar(&cloudImageID, "image-id", "", "ID of cloud image")
 	validateEgressCmd.MarkFlagRequired("subnet-id")
+	validateEgressCmd.MarkFlagRequired("image-id")
 
 	return validateEgressCmd
 

--- a/pkg/cloudclient/aws/aws.go
+++ b/pkg/cloudclient/aws/aws.go
@@ -38,6 +38,6 @@ func NewClient() (*Client, error) {
 	return c, nil
 }
 
-func (c *Client) ValidateEgress(ctx context.Context, VPCSubnetID string) error {
-	return c.validateEgress(ctx, VPCSubnetID)
+func (c *Client) ValidateEgress(ctx context.Context, vpcSubnetID, cloudImageID string) error {
+	return c.validateEgress(ctx, vpcSubnetID, cloudImageID)
 }

--- a/pkg/cloudclient/aws/private.go
+++ b/pkg/cloudclient/aws/private.go
@@ -19,9 +19,8 @@ import (
 )
 
 var (
-	AMIID         string = "ami-04902260ca3d33422" // should we hardcode this ??
-	InstanceType  string = "t2.micro"
-	InstanceCount int    = 1
+	instanceType  string = "t2.micro"
+	instanceCount int    = 1
 )
 
 func newClient(accessID, accessSecret, sessiontoken, region string) (*Client, error) {
@@ -205,7 +204,7 @@ func terminateEC2Instance(ec2Client *ec2.Client, instanceID string) error {
 	return nil
 }
 
-func (c *Client) validateEgress(ctx context.Context, VPCSubnetID string) error {
+func (c *Client) validateEgress(ctx context.Context, vpcSubnetID, cloudImageID string) error {
 	// Generate the userData file
 	userData, err := generateUserData()
 	if err != nil {
@@ -213,7 +212,7 @@ func (c *Client) validateEgress(ctx context.Context, VPCSubnetID string) error {
 	}
 
 	// Create an ec2 instance
-	instance, err := createEC2Instance(c.ec2Client, AMIID, InstanceType, InstanceCount, VPCSubnetID, userData)
+	instance, err := createEC2Instance(c.ec2Client, cloudImageID, instanceType, instanceCount, vpcSubnetID, userData)
 	if err != nil {
 		panic(fmt.Sprintf("Unable to create EC2 Instance: %s\n", err.Error()))
 	}

--- a/pkg/cloudclient/cloudclient.go
+++ b/pkg/cloudclient/cloudclient.go
@@ -16,7 +16,7 @@ type CloudClient interface {
 
 	// ValidateEgress validates that all required targets are reachable from the vpcsubnet
 	// required target are defined in https://docs.openshift.com/rosa/rosa_getting_started/rosa-aws-prereqs.html#osd-aws-privatelink-firewall-prerequisites
-	ValidateEgress(ctx context.Context, vpcsubnetid string) error
+	ValidateEgress(ctx context.Context, vpcSubnetID, cloudImageID string) error
 }
 
 var controllerMapping = map[configv1.PlatformType]Factory{}

--- a/pkg/cloudclient/gcp/gcp.go
+++ b/pkg/cloudclient/gcp/gcp.go
@@ -24,7 +24,7 @@ func (c *Client) ByoVPCValidator(context.Context) error {
 	return nil
 }
 
-func (c *Client) ValidateEgress(ctx context.Context, VPCSubnetID string) error {
+func (c *Client) ValidateEgress(ctx context.Context, vpcSubnetID, cloudImageID string) error {
 	return nil
 }
 


### PR DESCRIPTION
This adds `--image-id` as a CLI parameter and removes the hard-coded AMI ID in the aws cloudclient pkg.
```
$ ./osd-network-verifier egress --help
Usage:
  osd-network-verifier egress [flags]

Flags:
  -h, --help               help for egress
      --image-id string    ID of cloud image
      --subnet-id string   ID of the source subnet
```

This also makes a quick edit to the .gitignore to ignore *.swp files for Vim users.