### PR TITLE
Lengthen timeout to 1 second

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -5,4 +5,4 @@ WORKDIR /root/
 COPY /config.yaml /root/
 COPY /network-validator /usr/local/bin/
 
-ENTRYPOINT /usr/local/bin/network-validator --config=/root/config.yaml
+ENTRYPOINT /usr/local/bin/network-validator --config=/root/config.yaml --timeout=1s


### PR DESCRIPTION
.5 seconds is a bit short and causing flakiness, lengthening to 1 second is still reasonable and seems to reduce the flakiness