### PR TITLE
Implement configurable tags for cloud resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,12 @@ err = cli.ValidateEgress(context.TODO(), "vpcSubnetID", "cloudImageID")
 AWS_ACCESS_KEY_ID=<redacted> AWS_SECRET_ACCESS_KEY=<redacted> ./osd-network-verifier egress --subnet-id subnet-0ccetestsubnet1864 --image-id=ami-0df9a9ade3c65a1c7
 ```
 
+Optionally provide a list of tags to use outside of the default:
+
+```shell
+AWS_ACCESS_KEY_ID=<redacted> AWS_SECRET_ACCESS_KEY=<redacted> ./osd-network-verifier egress --subnet-id subnet-0ccetestsubnet1864 --image-id=ami-0df9a9ade3c65a1c7 --cloud-tags key=value,osd-network-verifier=owned
+```
+
 ## Other Subcommands
 
 Take a look at <https://github.com/openshift/osd-network-verifier/tree/main/cmd>

--- a/cmd/byovpc/cmd.go
+++ b/cmd/byovpc/cmd.go
@@ -16,7 +16,8 @@ func NewCmdByovpc(streams genericclioptions.IOStreams) *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			creds := credentials.NewStaticCredentialsProvider(os.Getenv("AWS_ACCESS_KEY_ID"), os.Getenv("AWS_SECRET_ACCESS_KEY"), os.Getenv("AWS_SESSION_TOKEN"))
 			region := os.Getenv("AWS_DEFAULT_REGION")
-			cli, err := cloudclient.NewClient(creds, region)
+			tags := map[string]string{}
+			cli, err := cloudclient.NewClient(creds, region, tags)
 
 			err = cli.ByoVPCValidator(context.TODO())
 			if err != nil {

--- a/cmd/egress/cmd.go
+++ b/cmd/egress/cmd.go
@@ -10,17 +10,22 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
 
+var defaultTags = map[string]string{
+	"osd-network-verifier": "owned",
+}
+
 func NewCmdValidateEgress(streams genericclioptions.IOStreams) *cobra.Command {
 	var vpcSubnetID string
 	var cloudImageID string
+	var cloudTags map[string]string
 
 	validateEgressCmd := &cobra.Command{
 		Use: "egress",
 		Run: func(cmd *cobra.Command, args []string) {
 			creds := credentials.NewStaticCredentialsProvider(os.Getenv("AWS_ACCESS_KEY_ID"), os.Getenv("AWS_SECRET_ACCESS_KEY"), os.Getenv("AWS_SESSION_TOKEN"))
 			region := os.Getenv("AWS_DEFAULT_REGION")
-			cli, err := cloudclient.NewClient(creds, region)
 
+			cli, err := cloudclient.NewClient(creds, region, cloudTags)
 			if err != nil {
 				streams.ErrOut.Write([]byte(err.Error()))
 				os.Exit(1)
@@ -39,6 +44,7 @@ func NewCmdValidateEgress(streams genericclioptions.IOStreams) *cobra.Command {
 
 	validateEgressCmd.Flags().StringVar(&vpcSubnetID, "subnet-id", "", "ID of the source subnet")
 	validateEgressCmd.Flags().StringVar(&cloudImageID, "image-id", "", "ID of cloud image")
+	validateEgressCmd.Flags().StringToStringVar(&cloudTags, "cloud-tags", defaultTags, "Comma-seperated list of tags to assign to cloud resources")
 	validateEgressCmd.MarkFlagRequired("subnet-id")
 
 	return validateEgressCmd

--- a/pkg/cloudclient/aws/aws.go
+++ b/pkg/cloudclient/aws/aws.go
@@ -17,6 +17,7 @@ const ClientIdentifier configv1.PlatformType = configv1.AWSPlatformType
 type Client struct {
 	ec2Client *ec2.Client
 	region    string
+	tags      map[string]string
 }
 
 func (c *Client) ByoVPCValidator(context.Context) error {
@@ -25,7 +26,7 @@ func (c *Client) ByoVPCValidator(context.Context) error {
 }
 
 // NewClient creates a new CloudClient for use with AWS.
-func NewClient(creds interface{}, region string) (client *Client, err error) {
+func NewClient(creds interface{}, region string, tags map[string]string) (client *Client, err error) {
 
 	switch c := creds.(type) {
 	case awscredsv1.Credentials:
@@ -35,6 +36,7 @@ func NewClient(creds interface{}, region string) (client *Client, err error) {
 				value.SecretAccessKey,
 				value.SessionToken,
 				region,
+				tags,
 			)
 		}
 	case awscredsv2.StaticCredentialsProvider:
@@ -43,6 +45,7 @@ func NewClient(creds interface{}, region string) (client *Client, err error) {
 			c.Value.SecretAccessKey,
 			c.Value.SessionToken,
 			region,
+			tags,
 		)
 	default:
 		err = fmt.Errorf("unsupported credentials type %T", c)

--- a/pkg/cloudclient/cloudclient.go
+++ b/pkg/cloudclient/cloudclient.go
@@ -24,12 +24,12 @@ type CloudClient interface {
 	ValidateEgress(ctx context.Context, vpcSubnetID, cloudImageID string) error
 }
 
-func NewClient(creds interface{}, region string) (CloudClient, error) {
+func NewClient(creds interface{}, region string, tags map[string]string) (CloudClient, error) {
 	switch c := creds.(type) {
 	case awscredsv1.Credentials, awscredsv2.StaticCredentialsProvider:
-		return awsCloudClient.NewClient(c, region)
+		return awsCloudClient.NewClient(c, region, tags)
 	case *google.Credentials:
-		return gcpCloudClient.NewClient(c, region)
+		return gcpCloudClient.NewClient(c, region, tags)
 	default:
 		return nil, fmt.Errorf("unsupported credentials type %T", c)
 	}

--- a/pkg/cloudclient/gcp/gcp.go
+++ b/pkg/cloudclient/gcp/gcp.go
@@ -18,6 +18,7 @@ type Client struct {
 	projectID      string
 	region         string
 	computeService *computev1.Service
+	tags           map[string]string
 }
 
 func (c *Client) ByoVPCValidator(context.Context) error {
@@ -29,13 +30,13 @@ func (c *Client) ValidateEgress(ctx context.Context, vpcSubnetID, cloudImageID s
 	return nil
 }
 
-func NewClient(credentials *google.Credentials, region string) (*Client, error) {
+func NewClient(credentials *google.Credentials, region string, tags map[string]string) (*Client, error) {
 	ctx := context.Background()
 	// initialize actual client
-	return newClient(ctx, credentials, region)
+	return newClient(ctx, credentials, region, tags)
 }
 
-func newClient(ctx context.Context, credentials *google.Credentials, region string) (*Client, error) {
+func newClient(ctx context.Context, credentials *google.Credentials, region string, tags map[string]string) (*Client, error) {
 	computeService, err := computev1.NewService(ctx, option.WithCredentials(credentials))
 	if err != nil {
 		return nil, err
@@ -45,5 +46,6 @@ func newClient(ctx context.Context, credentials *google.Credentials, region stri
 		projectID:      credentials.ProjectID,
 		region:         region,
 		computeService: computeService,
+		tags:           tags,
 	}, nil
 }


### PR DESCRIPTION
This adds a new command-line option to the osd-network-verifier tool `--cloud-tags` allowing a comma-seperated list of `key=value` pairs to be provided to the tool. The tool will use these key/value pairs to tag all EC2 instances created. The default list of tags is `osd-network-verifier=owned`, similar to the account operator's tags as defined in templated tooling.

```
$ ./osd-network-verifier egress --help
Usage:
  osd-network-verifier egress [flags]

Flags:
      --cloud-tags stringToString   Comma-seperated list of tags to assign to cloud resources (default [osd-network-verifier=owned])
```

![image](https://user-images.githubusercontent.com/5197933/145461941-72fb6668-d14d-4e5c-baa0-2450d2651b4e.png)
