### PR TITLE
Wait for verification that userdata script has completed and move to nitro instance type

### DIFF
--- a/cmd/egress/cmd.go
+++ b/cmd/egress/cmd.go
@@ -36,7 +36,14 @@ func NewCmdValidateEgress() *cobra.Command {
 			ctx := context.TODO()
 
 			creds := credentials.NewStaticCredentialsProvider(os.Getenv("AWS_ACCESS_KEY_ID"), os.Getenv("AWS_SECRET_ACCESS_KEY"), os.Getenv("AWS_SESSION_TOKEN"))
-			region := os.Getenv("AWS_DEFAULT_REGION")
+			// TODO this should probably be a command-line option that overwrites the env var
+			regionEnvVarStr := "AWS_DEFAULT_REGION"
+			regionDefault := "us-east-2"
+			region := os.Getenv(regionEnvVarStr)
+			if len(region) < 1 {
+				logger.Warn(ctx, "No region defined in %s env, defaulting to %s", regionEnvVarStr, regionDefault)
+				region = regionDefault
+			}
 
 			cli, err := cloudclient.NewClient(ctx, logger, creds, region, cloudTags)
 			if err != nil {


### PR DESCRIPTION
This includes several changes due to an issue that was revealed while adding the initial change to properly check for userdata completion:

1. Userdata script completion checking is added/changed to use regexp
2. Moving the default instance type to use a "nitro" t3.micro instance that supports continuous console log output
3. Providing the `latest=true` request parameter to the GetConsoleOutput EC2 API call to ensure the console log is updated before being provided in the response
4. Adding a default region `us-east-2` instead of assuming the AWS_DEFAULT_REGION variable is defined. We may want to consider add this as a command-line option as well.

This resolves a major issue where console output may not include the full userdata execution, depending on how long the userdata script takes to execute. After these changes, the egress check will execute reliably.