### PR TITLE
Adds instance type as CLI option and verifies hypervisor is nitro

### DIFF
--- a/cmd/byovpc/cmd.go
+++ b/cmd/byovpc/cmd.go
@@ -29,9 +29,13 @@ func NewCmdByovpc() *cobra.Command {
 			ctx := context.TODO()
 
 			creds := credentials.NewStaticCredentialsProvider(os.Getenv("AWS_ACCESS_KEY_ID"), os.Getenv("AWS_SECRET_ACCESS_KEY"), os.Getenv("AWS_SESSION_TOKEN"))
+
+			// TODO when this command is actually used, most if not all of the following should be command line options
 			region := os.Getenv("AWS_DEFAULT_REGION")
+			instanceType := "t3.micro"
 			tags := map[string]string{}
-			cli, err := cloudclient.NewClient(ctx, logger, creds, region, tags)
+
+			cli, err := cloudclient.NewClient(ctx, logger, creds, region, instanceType, tags)
 
 			err = cli.ByoVPCValidator(ctx)
 			if err != nil {

--- a/pkg/cloudclient/aws/aws.go
+++ b/pkg/cloudclient/aws/aws.go
@@ -16,10 +16,11 @@ const ClientIdentifier configv1.PlatformType = configv1.AWSPlatformType
 
 // Client represents an AWS Client
 type Client struct {
-	ec2Client *ec2.Client
-	region    string
-	tags      map[string]string
-	logger    ocmlog.Logger
+	ec2Client    *ec2.Client
+	region       string
+	instanceType string
+	tags         map[string]string
+	logger       ocmlog.Logger
 }
 
 func (c *Client) ByoVPCValidator(ctx context.Context) error {
@@ -28,7 +29,7 @@ func (c *Client) ByoVPCValidator(ctx context.Context) error {
 }
 
 // NewClient creates a new CloudClient for use with AWS.
-func NewClient(ctx context.Context, logger ocmlog.Logger, creds interface{}, region string, tags map[string]string) (client *Client, err error) {
+func NewClient(ctx context.Context, logger ocmlog.Logger, creds interface{}, region, instanceType string, tags map[string]string) (client *Client, err error) {
 
 	switch c := creds.(type) {
 	case awscredsv1.Credentials:
@@ -40,6 +41,7 @@ func NewClient(ctx context.Context, logger ocmlog.Logger, creds interface{}, reg
 				value.SecretAccessKey,
 				value.SessionToken,
 				region,
+				instanceType,
 				tags,
 			)
 		}
@@ -51,6 +53,7 @@ func NewClient(ctx context.Context, logger ocmlog.Logger, creds interface{}, reg
 			c.Value.SecretAccessKey,
 			c.Value.SessionToken,
 			region,
+			instanceType,
 			tags,
 		)
 	default:
@@ -58,7 +61,7 @@ func NewClient(ctx context.Context, logger ocmlog.Logger, creds interface{}, reg
 	}
 
 	if err != nil {
-		return nil, fmt.Errorf("couldn't create AWS client %w", err)
+		return nil, fmt.Errorf("Unable to create AWS client: %w", err)
 	}
 
 	return

--- a/pkg/cloudclient/cloudclient.go
+++ b/pkg/cloudclient/cloudclient.go
@@ -25,12 +25,12 @@ type CloudClient interface {
 	ValidateEgress(ctx context.Context, vpcSubnetID, cloudImageID string) error
 }
 
-func NewClient(ctx context.Context, logger ocmlog.Logger, creds interface{}, region string, tags map[string]string) (CloudClient, error) {
+func NewClient(ctx context.Context, logger ocmlog.Logger, creds interface{}, region, instanceType string, tags map[string]string) (CloudClient, error) {
 	switch c := creds.(type) {
 	case awscredsv1.Credentials, awscredsv2.StaticCredentialsProvider:
-		return awsCloudClient.NewClient(ctx, logger, c, region, tags)
+		return awsCloudClient.NewClient(ctx, logger, c, region, instanceType, tags)
 	case *google.Credentials:
-		return gcpCloudClient.NewClient(ctx, logger, c, region, tags)
+		return gcpCloudClient.NewClient(ctx, logger, c, region, instanceType, tags)
 	default:
 		return nil, fmt.Errorf("unsupported credentials type %T", c)
 	}

--- a/pkg/cloudclient/gcp/gcp.go
+++ b/pkg/cloudclient/gcp/gcp.go
@@ -17,6 +17,7 @@ const ClientIdentifier configv1.PlatformType = configv1.GCPPlatformType
 type Client struct {
 	projectID      string
 	region         string
+	instanceType   string
 	computeService *computev1.Service
 	tags           map[string]string
 	logger         ocmlog.Logger
@@ -31,12 +32,12 @@ func (c *Client) ValidateEgress(ctx context.Context, vpcSubnetID, cloudImageID s
 	return nil
 }
 
-func NewClient(ctx context.Context, logger ocmlog.Logger, credentials *google.Credentials, region string, tags map[string]string) (*Client, error) {
+func NewClient(ctx context.Context, logger ocmlog.Logger, credentials *google.Credentials, region, instanceType string, tags map[string]string) (*Client, error) {
 	// initialize actual client
-	return newClient(ctx, logger, credentials, region, tags)
+	return newClient(ctx, logger, credentials, region, instanceType, tags)
 }
 
-func newClient(ctx context.Context, logger ocmlog.Logger, credentials *google.Credentials, region string, tags map[string]string) (*Client, error) {
+func newClient(ctx context.Context, logger ocmlog.Logger, credentials *google.Credentials, region, instanceType string, tags map[string]string) (*Client, error) {
 	computeService, err := computev1.NewService(ctx, option.WithCredentials(credentials))
 	if err != nil {
 		return nil, err
@@ -45,6 +46,7 @@ func newClient(ctx context.Context, logger ocmlog.Logger, credentials *google.Cr
 	return &Client{
 		projectID:      credentials.ProjectID,
 		region:         region,
+		instanceType:   instanceType,
 		computeService: computeService,
 		tags:           tags,
 		logger:         logger,


### PR DESCRIPTION
This adds the `--instance-type=...` CLI option with a default of `t3.micro` to the osd-network-verifier CLI.

This also adds a post-client-creation check that reaches out to EC2 to ensure that the provided instance type uses the "nitro" hypervisor. The nitro hypervisor is required to allow the tool to reliably collect the userdata script output.

Providing an invalid instance type will now result in an error:
```
$ ./osd-network-verifier egress --subnet-id=subnet-0560aed436f77a99e --debug=true --instance-type=foobar
Gathering description of instance type foobar from EC2
Unable to create AWS client: Instance type foobar is invalid: Unable to gather list of supported instance types from EC2: Instance type foobar does not exist

$ ./osd-network-verifier egress --subnet-id=subnet-0560aed436f77a99e --debug=true --instance-type=t2.micro
Gathering description of instance type t2.micro from EC2
Full describe instance types output contains 1 instance types
Unable to create AWS client: Instance type t2.micro is invalid: Instance type must use hypervisor type 'nitro' to support reliable result collection
```