### PR TITLE
Fix makefile go flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,13 +12,13 @@ GOFLAGS=-mod=mod
 
 .PHONY: build
 build:
-	$(GOFLAGS) go fmt ./...
-	$(GOFLAGS) go mod tidy
-	$(GOFLAGS) go build .
+	go fmt ./...
+	go mod tidy
+	go build $(GOFLAGS) .
 
 .PHONY: test
-test: 
-	$(GOFLAGS) go test 
+test:
+	go test $(GOFLAGS)
 
 .PHONY: build-push
 build-push:


### PR DESCRIPTION
The go flags were previously set prior to the run of the command,
resulting in two issues:
1. The exit code of the `make build` command was always 0 since -mod=mod
   would always return 0
2. The go commands didn't actually receive the flag

Note that `go mod` and `go fmt` don't accept/honor the -mod flag, so the
GOFLAGS have been removed from those.

Verified with:
```
$ make ; echo $?
Makefile:29: warning: overriding recipe for target 'skopeo-push'
standard.mk:40: warning: ignoring old recipe for target 'skopeo-push'
go fmt ./...
go mod tidy
go build -mod=mod .
0

$ echo "BREAK" >> pkg/cloudclient/aws/aws.go 

$ make ; echo $?
Makefile:29: warning: overriding recipe for target 'skopeo-push'
standard.mk:40: warning: ignoring old recipe for target 'skopeo-push'
go fmt ./...
pkg/cloudclient/aws/aws.go:70:1: expected declaration, found BREAK
exit status 2
make: *** [Makefile:15: build] Error 1
2
```