### PR TITLE
[OSD-9351] Exit 0 when network validation script runs successfully

### DIFF
--- a/build/bin/network-validator.go
+++ b/build/bin/network-validator.go
@@ -78,7 +78,11 @@ func TestEndpoints(config reachabilityConfig) {
 	for _, f := range failures {
 		fmt.Println(f)
 	}
-	os.Exit(1)
+	// NOTE even though not all endpoints were reachable, the script still completed successfully. To ensure
+	// the docker image run doesn't abort when not all endpoints are reachable, we exit with a 0 code here.
+	// This may make it difficult when directly using the script to rely on the exit code to determine if
+	// endpoints were reachable or not, but there is not a use case for that as of this writing.
+	os.Exit(0)
 }
 
 func ValidateReachability(host string, port int) error {


### PR DESCRIPTION
https://issues.redhat.com/browse/OSD-9351

In the case where the script completes but one or more endpoints are not
reachable, we should exit with a 0 code instead of 1. This will help
ensure that the run of the docker image does not abort early when
endpoints are not reachable.

This change does mean that it will be more difficult to use the script
programatically outside of the existing osd-network-verifier tooling,
but as there is no use-case for that today this should be the most
reliable option.