### PR TITLE
bug: fix running tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ build:
 
 .PHONY: test
 test:
-	go test $(GOFLAGS)
+	go test $(GOFLAGS) ./...
 
 .PHONY: build-push
 build-push:


### PR DESCRIPTION
Type: Bug

Currently the testing function doesn't actually run all the tests under osd-network-verifier

```shell
make test
Makefile:29: warning: overriding recipe for target 'skopeo-push'
standard.mk:40: warning: ignoring old recipe for target 'skopeo-push'
go test -mod=mod
?       github.com/openshift/osd-network-verifier       [no test files]
```

This PR transforms it to

```shell
make test
Makefile:29: warning: overriding recipe for target 'skopeo-push'
standard.mk:40: warning: ignoring old recipe for target 'skopeo-push'
go test -mod=mod ./...
?       github.com/openshift/osd-network-verifier       [no test files]
?       github.com/openshift/osd-network-verifier/build/bin     [no test files]
?       github.com/openshift/osd-network-verifier/cmd   [no test files]
?       github.com/openshift/osd-network-verifier/cmd/byovpc    [no test files]
?       github.com/openshift/osd-network-verifier/cmd/egress    [no test files]
?       github.com/openshift/osd-network-verifier/pkg/cloudclient       [no test files]
ok      github.com/openshift/osd-network-verifier/pkg/cloudclient/aws   0.008s
ok      github.com/openshift/osd-network-verifier/pkg/cloudclient/gcp   0.007s
?       github.com/openshift/osd-network-verifier/pkg/cloudclient/mocks [no test files]
```