### PR TITLE
ci: exclude build as it's already covered in dockerization

### DIFF
--- a/hack/app_sre_build_push.sh
+++ b/hack/app_sre_build_push.sh
@@ -90,4 +90,4 @@ if image_exists_in_repo "$IMAGE_URI"; then
     exit 0
 fi
 
-make IMAGE_REPOSITORY=${IMAGE_REPOSITORY:-app-sre} build skopeo-push
+make IMAGE_REPOSITORY=${IMAGE_REPOSITORY:-app-sre} skopeo-push


### PR DESCRIPTION
Removing `build` from containerization process as it's no needed
The build is currently breaking app-sre pipeline:  https://ci.int.devshift.net/view/osd-operators/job/openshift-osd-network-verifier-gh-build-main/1/console
