### PR TITLE
fix: update the image to the one that's in app-sre

### DIFF
--- a/pkg/cloudclient/aws/private.go
+++ b/pkg/cloudclient/aws/private.go
@@ -47,7 +47,7 @@ var (
 		"me-south-1":     "",
 	}
 	// TODO find a location for future docker images
-	networkValidatorImage string = "quay.io/twilliams725/osd-network-verifier:2"
+	networkValidatorImage string = "quay.io/app-sre/osd-network-verifier:v81-bf8360e"
 	userdataEndVerifier   string = "USERDATA END"
 )
 


### PR DESCRIPTION
As we have now the validator images in place: https://quay.io/repository/app-sre/osd-network-verifier?tag=latest&tab=tags