### PR TITLE
Add Managed Openshift standard tag and Name tag

### DIFF
--- a/cmd/egress/cmd.go
+++ b/cmd/egress/cmd.go
@@ -13,7 +13,7 @@ import (
 )
 
 var (
-	defaultTags            = map[string]string{"osd-network-verifier": "owned"}
+	defaultTags            = map[string]string{"osd-network-verifier": "owned", "red-hat-managed": "true", "Name": "osd-network-verifier"}
 	regionEnvVarStr string = "AWS_DEFAULT_REGION"
 	regionDefault   string = "us-east-2"
 )


### PR DESCRIPTION
To align with the rest of Managed Openshift, this PR adds the `red-hat-managed: true` tag to the ec2 instance created by the verifier. Also adds a name tag for better identification.

REF: https://issues.redhat.com/browse/OSD-9874