### PR TITLE
bug: handle the case when docker cannot be installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,14 @@ region := "us-east-1"
 
 // init a cloudclient
 cli, err := cloudclient.NewClient(creds, region)
-
 // ... error checking
 
-// call the validation function
-err = cli.ValidateEgress(context.TODO(), "vpcSubnetID", "cloudImageID")
-
-// ... error checking
+// call the validation function and check if it was successful
+out := cli.ValidateEgress(context.TODO(), "vpcSubnetID", "cloudImageID")
+if !out.IsSuccessful() {
+    // Failure
+    failures, exceptions, errors := out.Parse()
+}
 ```
 
 #### using aws-sdk-go-v1
@@ -59,13 +60,13 @@ region := "us-east-1"
 
 // init a cloudclient
 cli, err := cloudclient.NewClient(*creds, region)
-
 // ... error checking
 
-// call the validation function
-err = cli.ValidateEgress(context.TODO(), "vpcSubnetID", "cloudImageID")
-
-// ... error checking
+out := cli.ValidateEgress(context.TODO(), "vpcSubnetID", "cloudImageID")
+if !out.IsSuccessful() {
+    // Failure
+    failures, exceptions, errors := out.Parse()
+}
 ```
 
 ### Validate egress using command line

--- a/cmd/egress/cmd.go
+++ b/cmd/egress/cmd.go
@@ -42,6 +42,9 @@ func NewCmdValidateEgress() *cobra.Command {
 	validateEgressCmd := &cobra.Command{
 		Use: "egress",
 		Run: func(cmd *cobra.Command, args []string) {
+			// ctx
+			ctx := context.TODO()
+
 			// Create logger
 			builder := ocmlog.NewStdLoggerBuilder()
 			builder.Debug(config.debug)
@@ -51,25 +54,22 @@ func NewCmdValidateEgress() *cobra.Command {
 				os.Exit(1)
 			}
 
-			ctx := context.TODO()
-
-			creds := credentials.NewStaticCredentialsProvider(os.Getenv("AWS_ACCESS_KEY_ID"), os.Getenv("AWS_SECRET_ACCESS_KEY"), os.Getenv("AWS_SESSION_TOKEN"))
-
 			logger.Warn(ctx, "Using region: %s", config.region)
+			creds := credentials.NewStaticCredentialsProvider(os.Getenv("AWS_ACCESS_KEY_ID"), os.Getenv("AWS_SECRET_ACCESS_KEY"), os.Getenv("AWS_SESSION_TOKEN"))
 			cli, err := cloudclient.NewClient(ctx, logger, creds, config.region, config.instanceType, config.cloudTags)
 			if err != nil {
 				logger.Error(ctx, err.Error())
 				os.Exit(1)
 			}
-			err = cli.ValidateEgress(ctx, config.vpcSubnetID, config.cloudImageID, config.timeout)
 
-			if err != nil {
-				logger.Error(ctx, err.Error())
+			out := cli.ValidateEgress(ctx, config.vpcSubnetID, config.cloudImageID, config.timeout)
+			out.Summary()
+			if !out.IsSuccessful() {
+				logger.Error(ctx, "Failure!")
 				os.Exit(1)
 			}
 
 			logger.Info(ctx, "Success")
-
 		},
 	}
 

--- a/main.go
+++ b/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"flag"
-	"fmt"
 	"os"
 
 	"github.com/openshift/osd-network-verifier/cmd"
@@ -15,11 +14,7 @@ func main() {
 	flag.CommandLine.Parse([]string{})
 	pflag.CommandLine = flags
 
-	//command := cmd.NewCmdRoot(genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr})
-	command := cmd.NewCmdRoot()
-
-	if err := command.Execute(); err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
+	if err := cmd.NewCmdRoot().Execute(); err != nil {
 		os.Exit(1)
 	}
 }

--- a/pkg/cloudclient/aws/aws.go
+++ b/pkg/cloudclient/aws/aws.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	awscredsv1 "github.com/aws/aws-sdk-go/aws/credentials"
 	ocmlog "github.com/openshift-online/ocm-sdk-go/logging"
+	"github.com/openshift/osd-network-verifier/pkg/output"
 )
 
 // ClientIdentifier is what kind of cloud this implement supports
@@ -21,6 +22,7 @@ type Client struct {
 	instanceType string
 	tags         map[string]string
 	logger       ocmlog.Logger
+	output       output.Output
 }
 
 // Extend EC2Client so that we can mock them all for testing
@@ -37,6 +39,10 @@ type EC2Client interface {
 func (c *Client) ByoVPCValidator(ctx context.Context) error {
 	c.logger.Info(ctx, "interface executed: %s", ClientIdentifier)
 	return nil
+}
+
+func (c *Client) ValidateEgress(ctx context.Context, vpcSubnetID, cloudImageID string, timeout time.Duration) *output.Output {
+	return c.validateEgress(ctx, vpcSubnetID, cloudImageID, timeout)
 }
 
 // NewClient creates a new CloudClient for use with AWS.
@@ -76,8 +82,4 @@ func NewClient(ctx context.Context, logger ocmlog.Logger, creds interface{}, reg
 	}
 
 	return
-}
-
-func (c *Client) ValidateEgress(ctx context.Context, vpcSubnetID, cloudImageID string, timeout time.Duration) error {
-	return c.validateEgress(ctx, vpcSubnetID, cloudImageID, timeout)
 }

--- a/pkg/cloudclient/aws/private.go
+++ b/pkg/cloudclient/aws/private.go
@@ -18,6 +18,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	ocmlog "github.com/openshift-online/ocm-sdk-go/logging"
 	"github.com/openshift/osd-network-verifier/pkg/helpers"
+	"github.com/openshift/osd-network-verifier/pkg/output"
 )
 
 var (
@@ -70,6 +71,7 @@ func newClient(ctx context.Context, logger ocmlog.Logger, accessID, accessSecret
 		instanceType: instanceType,
 		tags:         tags,
 		logger:       logger,
+		output:       output.Output{},
 	}
 
 	// Validates the provided instance type will work with the verifier
@@ -99,7 +101,7 @@ func buildTags(tags map[string]string) []ec2Types.TagSpecification {
 	return []ec2Types.TagSpecification{tagSpec}
 }
 
-func (c Client) validateInstanceType(ctx context.Context) error {
+func (c *Client) validateInstanceType(ctx context.Context) error {
 	// Describe the provided instance type only
 	//      https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/ec2#DescribeInstanceTypesInput
 	descInput := ec2.DescribeInstanceTypesInput{
@@ -137,7 +139,7 @@ func (c Client) validateInstanceType(ctx context.Context) error {
 	return nil
 }
 
-func (c Client) createEC2Instance(ctx context.Context, amiID string, instanceCount int, vpcSubnetID, userdata string, tags map[string]string) (ec2.RunInstancesOutput, error) {
+func (c *Client) createEC2Instance(ctx context.Context, amiID, vpcSubnetID, userdata string, instanceCount int) (ec2.RunInstancesOutput, error) {
 	// Build our request, converting the go base types into the pointers required by the SDK
 	instanceReq := ec2.RunInstancesInput{
 		ImageId:      aws.String(amiID),
@@ -153,7 +155,7 @@ func (c Client) createEC2Instance(ctx context.Context, amiID string, instanceCou
 			},
 		},
 		UserData:          aws.String(userdata),
-		TagSpecifications: buildTags(tags),
+		TagSpecifications: buildTags(c.tags),
 	}
 	// Finally, we make our request
 	instanceResp, err := c.ec2Client.RunInstances(ctx, &instanceReq)
@@ -169,7 +171,7 @@ func (c Client) createEC2Instance(ctx context.Context, amiID string, instanceCou
 }
 
 // Returns state code as int
-func (c Client) describeEC2Instances(ctx context.Context, instanceID string) (int, error) {
+func (c *Client) describeEC2Instances(ctx context.Context, instanceID string) (int, error) {
 	// States and codes
 	// 0 : pending
 	// 16 : running
@@ -207,7 +209,7 @@ func (c Client) describeEC2Instances(ctx context.Context, instanceID string) (in
 	return int(*result.InstanceStatuses[0].InstanceState.Code), nil
 }
 
-func (c Client) waitForEC2InstanceCompletion(ctx context.Context, instanceID string) error {
+func (c *Client) waitForEC2InstanceCompletion(ctx context.Context, instanceID string) error {
 	//wait for the instance to run
 	totalWait := 25 * 60
 	currentWait := 1
@@ -253,9 +255,7 @@ func generateUserData(variables map[string]string) (string, error) {
 	return base64.StdEncoding.EncodeToString([]byte(data)), nil
 }
 
-func (c Client) findUnreachableEndpoints(ctx context.Context, instanceID string) ([]string, error) {
-	var match []string
-
+func (c *Client) findUnreachableEndpoints(ctx context.Context, instanceID string) {
 	// Compile the regular expressions once
 	reVerify := regexp.MustCompile(userdataEndVerifier)
 	reUnreachableErrors := regexp.MustCompile(`Unable to reach (\S+)`)
@@ -266,7 +266,7 @@ func (c Client) findUnreachableEndpoints(ctx context.Context, instanceID string)
 		Latest:     &latest,
 	}
 
-	err := helpers.PollImmediate(30*time.Second, 10*time.Minute, func() (bool, error) {
+	_ = helpers.PollImmediate(30*time.Second, 10*time.Minute, func() (bool, error) {
 		output, err := c.ec2Client.GetConsoleOutput(ctx, &input)
 		if err == nil && output.Output != nil {
 			// First, gather the ec2 console output
@@ -291,33 +291,51 @@ func (c Client) findUnreachableEndpoints(ctx context.Context, instanceID string)
 				return false, nil
 			}
 
+			// check output failures, report as exception if they occurred
+			var rgx = regexp.MustCompile(`(?m)^(.*Cannot.*)|(.*Could not.*)|(.*Failed.*)|(.*command not found.*)`)
+			notFoundMatch := rgx.FindAllStringSubmatch(string(scriptOutput), -1)
+			if len(notFoundMatch) > 0 {
+				for _, v := range notFoundMatch {
+					c.output.AddException(v[0])
+				}
+			}
+
 			// If debug logging is enabled, output the full console log that appears to include the full userdata run
 			c.logger.Debug(ctx, "Full EC2 console output:\n---\n%s\n---", scriptOutput)
 
-			match = reUnreachableErrors.FindAllString(string(scriptOutput), -1)
-
+			c.output.SetFailures(reUnreachableErrors.FindAllString(string(scriptOutput), -1))
 			return true, nil
 		}
 		c.logger.Debug(ctx, "Waiting for UserData script to complete...")
 		return false, nil
 	})
-	return match, err
 }
 
-func (c Client) terminateEC2Instance(ctx context.Context, instanceID string) error {
+func (c *Client) terminateEC2Instance(ctx context.Context, instanceID string) {
+	c.logger.Info(ctx, "Terminating ec2 instance with id %s", instanceID)
 	input := ec2.TerminateInstancesInput{
 		InstanceIds: []string{instanceID},
 	}
 	_, err := c.ec2Client.TerminateInstances(ctx, &input)
-	if err != nil {
-		c.logger.Error(ctx, "Unable to terminate EC2 instance: %s", err.Error())
-		return err
-	}
-
-	return nil
+	c.output.AddError(err)
 }
 
-func (c *Client) validateEgress(ctx context.Context, vpcSubnetID, cloudImageID string, timeout time.Duration) error {
+func (c *Client) setCloudImage(cloudImageID string) (string, error) {
+	// If a cloud image wasn't provided by the caller,
+	if cloudImageID == "" {
+		// use defaultAmi for the region instead
+		cloudImageID = defaultAmi[c.region]
+		if cloudImageID == "" {
+			return "", fmt.Errorf("no default ami found for region %s ", c.region)
+		}
+	}
+
+	return cloudImageID, nil
+}
+
+// validateEgress returns 3 values that represents
+// Failures, Exceptions that occured during validation, unhandled errors
+func (c *Client) validateEgress(ctx context.Context, vpcSubnetID, cloudImageID string, timeout time.Duration) *output.Output {
 	c.logger.Debug(ctx, "Using configured timeout of %s for each egress request", timeout.String())
 	// Generate the userData file
 	userDataVariables := map[string]string{
@@ -331,50 +349,30 @@ func (c *Client) validateEgress(ctx context.Context, vpcSubnetID, cloudImageID s
 	}
 	userData, err := generateUserData(userDataVariables)
 	if err != nil {
-		err = fmt.Errorf("Unable to generate UserData file: %s", err.Error())
-		return err
+		return c.output.AddErrorAndReturn(err)
 	}
 	c.logger.Debug(ctx, "Base64-encoded generated userdata script:\n---\n%s\n---", userData)
 
-	// If a cloud image wasn't provided by the caller,
-	if cloudImageID == "" {
-		// use defaultAmi for the region instead
-		cloudImageID = defaultAmi[c.region]
-
-		if cloudImageID == "" {
-			return fmt.Errorf("No default AMI found for region %s ", c.region)
-		}
-	}
-
-	// Create an ec2 instance
-	instance, err := c.createEC2Instance(ctx, cloudImageID, instanceCount, vpcSubnetID, userData, c.tags)
+	cloudImageID, err = c.setCloudImage(cloudImageID)
 	if err != nil {
-		err = fmt.Errorf("Unable to create EC2 Instance: %s", err.Error())
-		return err
+		return c.output.AddErrorAndReturn(err) // fatal
 	}
+
+	instance, err := c.createEC2Instance(ctx, cloudImageID, vpcSubnetID, userData, instanceCount)
+	if err != nil {
+		return c.output.AddErrorAndReturn(err) // fatal
+	}
+
 	instanceID := *instance.Instances[0].InstanceId
-
-	// Wait for the ec2 instance to be running
 	c.logger.Debug(ctx, "Waiting for EC2 instance %s to be running", instanceID)
-	err = c.waitForEC2InstanceCompletion(ctx, instanceID)
-	if err != nil {
-		err = fmt.Errorf("Error while waiting for EC2 instance to start: %s", err.Error())
-		return err
-	}
-	c.logger.Info(ctx, "Gathering and parsing console log output...")
-	unreachableEndpoints, err := c.findUnreachableEndpoints(ctx, instanceID)
-	if err != nil {
-		c.logger.Error(ctx, "Error parsing output from console log: %s", err.Error())
-		return err
+	if instanceReadyErr := c.waitForEC2InstanceCompletion(ctx, instanceID); instanceReadyErr != nil {
+		c.terminateEC2Instance(ctx, instanceID)             // try to terminate the created instance
+		return c.output.AddErrorAndReturn(instanceReadyErr) // fatal
 	}
 
-	c.logger.Info(ctx, "Terminating ec2 instance with id %s", instanceID)
-	if err := c.terminateEC2Instance(ctx, instanceID); err != nil {
-		err = fmt.Errorf("Error terminating instances: %s", err.Error())
-		return err
-	}
-	if len(unreachableEndpoints) > 0 {
-		return fmt.Errorf("multiple targets unreachable %q", unreachableEndpoints)
-	}
-	return nil
+	c.logger.Info(ctx, "Gathering and parsing console log output...")
+	c.findUnreachableEndpoints(ctx, instanceID)
+	c.terminateEC2Instance(ctx, instanceID)
+
+	return &c.output
 }

--- a/pkg/cloudclient/aws/private_test.go
+++ b/pkg/cloudclient/aws/private_test.go
@@ -2,7 +2,9 @@ package aws
 
 import (
 	"context"
+	"encoding/base64"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -29,12 +31,56 @@ func TestCreateEC2Instance(t *testing.T) {
 		ec2Client: FakeEC2Cli,
 		logger:    &logging.GlogLogger{},
 	}
-	out, err := cli.createEC2Instance(context.Background(), "test-ami", 1, "", "test", map[string]string{})
+	out, err := cli.createEC2Instance(context.Background(), "test-ami", "test", "", 1)
 	if err != nil {
 		t.Errorf("instance should be created")
 	}
 
 	if aws.ToString(out.Instances[0].InstanceId) != testID {
 		t.Errorf("instance ID mismatch")
+	}
+}
+
+func TestValidateEgress(t *testing.T) {
+	testID := "aws-docs-example-instanceID"
+	vpcSubnetID, cloudImageID := "dummy-id", "dummy-id"
+	consoleOut := `[   48.062407] cloud-init[2472]: Cloud-init v. 19.3-44.amzn2 running 'modules:final' at Mon, 07 Feb 2022 12:30:22 +0000. Up 48.00 seconds.
+	[   48.077429] cloud-init[2472]: USERDATA BEGIN
+	[   48.138248] cloud-init[2472]: USERDATA END`
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	FakeEC2Cli := mocks.NewMockEC2Client(ctrl)
+
+	FakeEC2Cli.EXPECT().RunInstances(gomock.Any(), gomock.Any()).Times(1).Return(&ec2.RunInstancesOutput{
+		Instances: []types.Instance{{
+			InstanceId: aws.String(testID),
+		}},
+	}, nil)
+
+	FakeEC2Cli.EXPECT().DescribeInstanceStatus(gomock.Any(), gomock.Any()).Times(1).Return(&ec2.DescribeInstanceStatusOutput{
+		InstanceStatuses: []types.InstanceStatus{{
+			InstanceId: aws.String(testID),
+			InstanceState: &types.InstanceState{
+				Code: aws.Int32(16),
+			},
+		},
+		},
+	}, nil)
+
+	encodedconsoleOut := base64.StdEncoding.EncodeToString([]byte(consoleOut))
+	FakeEC2Cli.EXPECT().GetConsoleOutput(gomock.Any(), gomock.Any()).Times(1).Return(&ec2.GetConsoleOutputOutput{
+		Output: aws.String(encodedconsoleOut),
+	}, nil)
+
+	FakeEC2Cli.EXPECT().TerminateInstances(gomock.Any(), gomock.Any()).Times(1).Return(nil, nil)
+
+	cli := Client{
+		ec2Client: FakeEC2Cli,
+		logger:    &logging.GlogLogger{},
+	}
+
+	if !cli.validateEgress(context.TODO(), vpcSubnetID, cloudImageID, time.Duration(1*time.Second)).IsSuccessful() {
+		t.Errorf("validateEgress(): should pass")
 	}
 }

--- a/pkg/cloudclient/cloudclient.go
+++ b/pkg/cloudclient/cloudclient.go
@@ -10,6 +10,7 @@ import (
 	ocmlog "github.com/openshift-online/ocm-sdk-go/logging"
 	awsCloudClient "github.com/openshift/osd-network-verifier/pkg/cloudclient/aws"
 	gcpCloudClient "github.com/openshift/osd-network-verifier/pkg/cloudclient/gcp"
+	"github.com/openshift/osd-network-verifier/pkg/output"
 
 	"golang.org/x/oauth2/google"
 )
@@ -22,8 +23,9 @@ type CloudClient interface {
 	ByoVPCValidator(ctx context.Context) error
 
 	// ValidateEgress validates that all required targets are reachable from the vpcsubnet
-	// required target are defined in https://docs.openshift.com/rosa/rosa_getting_started/rosa-aws-prereqs.html#osd-aws-privatelink-firewall-prerequisites
-	ValidateEgress(ctx context.Context, vpcSubnetID, cloudImageID string, timeout time.Duration) error
+	// target URLs: https://docs.openshift.com/rosa/rosa_getting_started/rosa-aws-prereqs.html#osd-aws-privatelink-firewall-prerequisites
+	// Expected return value is *output.Output that's storing failures, exceptions and errors
+	ValidateEgress(ctx context.Context, vpcSubnetID, cloudImageID string, timeout time.Duration) *output.Output
 }
 
 func NewClient(ctx context.Context, logger ocmlog.Logger, creds interface{}, region, instanceType string, tags map[string]string) (CloudClient, error) {

--- a/pkg/cloudclient/gcp/gcp.go
+++ b/pkg/cloudclient/gcp/gcp.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	ocmlog "github.com/openshift-online/ocm-sdk-go/logging"
+	"github.com/openshift/osd-network-verifier/pkg/output"
 	"golang.org/x/oauth2/google"
 	computev1 "google.golang.org/api/compute/v1"
 	"google.golang.org/api/option"
@@ -21,6 +22,7 @@ type Client struct {
 	computeService *computev1.Service
 	tags           map[string]string
 	logger         ocmlog.Logger
+	output         output.Output
 }
 
 func (c *Client) ByoVPCValidator(ctx context.Context) error {
@@ -28,8 +30,8 @@ func (c *Client) ByoVPCValidator(ctx context.Context) error {
 	return nil
 }
 
-func (c *Client) ValidateEgress(ctx context.Context, vpcSubnetID, cloudImageID string, timeout time.Duration) error {
-	return nil
+func (c *Client) ValidateEgress(ctx context.Context, vpcSubnetID, cloudImageID string, timeout time.Duration) *output.Output {
+	return &c.output
 }
 
 func NewClient(ctx context.Context, logger ocmlog.Logger, credentials *google.Credentials, region, instanceType string, tags map[string]string) (*Client, error) {

--- a/pkg/cloudclient/gcp/gcp_test.go
+++ b/pkg/cloudclient/gcp/gcp_test.go
@@ -25,9 +25,8 @@ func TestValidateEgress(t *testing.T) {
 	cloudImageID := "image-id"
 	cli := Client{}
 	timeout := 1 * time.Second
-	err := cli.ValidateEgress(ctx, subnetID, cloudImageID, timeout)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
+	if !cli.ValidateEgress(ctx, subnetID, cloudImageID, timeout).IsSuccessful() {
+		t.Errorf("validation should have been successful")
 	}
 }
 

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -14,25 +14,30 @@ type Output struct {
 	errors     []error
 }
 
+// AddError adds error to the list of errors
 func (o *Output) AddError(err error) {
 	if err != nil {
 		o.errors = append(o.errors, err)
 	}
 }
 
+// AddErrorAndReturn calls AddError then returns the object itself
 func (o *Output) AddErrorAndReturn(err error) *Output {
 	o.AddError(err)
 	return o
 }
 
+// AddException adds an exception to the list of exceptions
 func (o *Output) AddException(message string) {
 	o.exceptions = append(o.exceptions, message)
 }
 
+// SetFailures sets failures as a bulk update
 func (o *Output) SetFailures(failures []string) {
 	o.failures = failures
 }
 
+// IsSuccessful checks whether the output contains any item, returns false if there's any
 func (o *Output) IsSuccessful() bool {
 	if len(o.errors) > 0 || len(o.exceptions) > 0 || len(o.failures) > 0 {
 		return false
@@ -62,6 +67,7 @@ func (o *Output) printErrors() {
 	}
 }
 
+// Summary can be used for printing out output structure
 func (o *Output) Summary() {
 	fmt.Println("Summary:")
 	o.printFailures()
@@ -69,6 +75,10 @@ func (o *Output) Summary() {
 	o.printErrors()
 }
 
+// Parse returns the data being stored on output
+// - failures as []string
+// - exceptions as []string
+// - errors as []error
 func (o *Output) Parse() ([]string, []string, []error) {
 	return o.failures, o.exceptions, o.errors
 }

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -1,0 +1,74 @@
+package output
+
+import (
+	"fmt"
+)
+
+// Output can be used when showcasing validation results at the end of the execution.
+// `failures` represents the failed validation tests
+// `exceptions` is to show edge cases where onv couldn't be ended up as expected
+// `errors` is collection of unhandled errors
+type Output struct {
+	failures   []string
+	exceptions []string
+	errors     []error
+}
+
+func (o *Output) AddError(err error) {
+	if err != nil {
+		o.errors = append(o.errors, err)
+	}
+}
+
+func (o *Output) AddErrorAndReturn(err error) *Output {
+	o.AddError(err)
+	return o
+}
+
+func (o *Output) AddException(message string) {
+	o.exceptions = append(o.exceptions, message)
+}
+
+func (o *Output) SetFailures(failures []string) {
+	o.failures = failures
+}
+
+func (o *Output) IsSuccessful() bool {
+	if len(o.errors) > 0 || len(o.exceptions) > 0 || len(o.failures) > 0 {
+		return false
+	}
+
+	return true
+}
+
+func (o *Output) printFailures() {
+	fmt.Println("printing out failures:")
+	for _, v := range o.failures {
+		fmt.Println(" - ", v)
+	}
+}
+
+func (o *Output) printExceptions() {
+	fmt.Println("printing out exceptions preventing onv from running:")
+	for _, v := range o.exceptions {
+		fmt.Println(" - ", v)
+	}
+}
+
+func (o *Output) printErrors() {
+	fmt.Println("printing out errors faced during the execution:")
+	for _, v := range o.errors {
+		fmt.Println(" - ", v.Error())
+	}
+}
+
+func (o *Output) Summary() {
+	fmt.Println("Summary:")
+	o.printFailures()
+	o.printExceptions()
+	o.printErrors()
+}
+
+func (o *Output) Parse() ([]string, []string, []error) {
+	return o.failures, o.exceptions, o.errors
+}


### PR DESCRIPTION
Fix: https://issues.redhat.com/browse/OSD-9875

Example execution
```shell
AWS_ACCESS_KEY_ID=redacted AWS_SECRET_ACCESS_KEY=redacted ./osd-network-verifier egress --subnet-id subnet-024243d552dsomeid --region us-east-1
Using region: us-east-1
Created instance with ID: i-05924e5e7860de75f
EC2 Instance: i-05924e5e7860de75f Running
Gathering and parsing console log output...
Terminating ec2 instance with id i-05924e5e7860de75f
Summary:
printing out failures:
printing out exceptions preventing onv from running:
 -  [   29.347841] cloud-init[2255]: Cannot find a valid baseurl for repo: amzn2-core/2/x86_64
 -  [   29.365916] cloud-init[2255]: Could not retrieve mirrorlist https://amazonlinux-2-repos-us-east-1.s3.dualstack.us-east-1.amazonaws.com/2/core/latest/x86_64/mirror.list error was
 -  [   29.366417] cloud-init[2255]: 12: Timeout on https://amazonlinux-2-repos-us-east-1.s3.dualstack.us-east-1.amazonaws.com/2/core/latest/x86_64/mirror.list: (28, 'Failed to connect to amazonlinux-2-repos-us-east-1.s3.dualstack.us-east-1.amazonaws.com port 443: Connection timed out')
 -  [   49.134395] cloud-init[2255]: Cannot find a valid baseurl for repo: amzn2-core/2/x86_64
 -  [   49.138429] cloud-init[2255]: Could not retrieve mirrorlist https://amazonlinux-2-repos-us-east-1.s3.dualstack.us-east-1.amazonaws.com/2/core/latest/x86_64/mirror.list error was
 -  [   49.141130] cloud-init[2255]: 12: Timeout on https://amazonlinux-2-repos-us-east-1.s3.dualstack.us-east-1.amazonaws.com/2/core/latest/x86_64/mirror.list: (28, 'Failed to connect to amazonlinux-2-repos-us-east-1.s3.dualstack.us-east-1.amazonaws.com port 443: Connection timed out')
 -  [   49.175760] cloud-init[2255]: Feb 08 13:19:20 cloud-init[2255]: util.py[WARNING]: Failed to install packages: ['docker']
 -  [   49.791913] cloud-init[2457]: Failed to start docker.service: Unit not found.
 -  [   49.803726] cloud-init[2457]: sudo: docker: command not found
 -  [   49.811887] cloud-init[2457]: sudo: docker: command not found
printing out errors faced during the execution:
Failure!
```

When there's missing permission for the iam user (in order to see combined errors):
- `ec2:TerminateInstances`
```shell
Using region: us-east-1
Created instance with ID: i-0bd77556b2349f421
EC2 Instance: i-0bd77556b2349f421 Running
Gathering and parsing console log output...
Terminating ec2 instance with id i-0bd77556b2349f421
Summary:
printing out failures:
printing out exceptions preventing onv from running:
 -  [   31.176579] cloud-init[2255]: Cannot find a valid baseurl for repo: amzn2-core/2/x86_64
 -  [   31.176815] cloud-init[2255]: Could not retrieve mirrorlist https://amazonlinux-2-repos-us-east-1.s3.dualstack.us-east-1.amazonaws.com/2/core/latest/x86_64/mirror.list error was
 -  [   31.177023] cloud-init[2255]: 12: Timeout on https://amazonlinux-2-repos-us-east-1.s3.dualstack.us-east-1.amazonaws.com/2/core/latest/x86_64/mirror.list: (28, 'Failed to connect to amazonlinux-2-repos-us-east-1.s3.dualstack.us-east-1.amazonaws.com port 443: Connection timed out')
 -  [   50.720302] cloud-init[2255]: Cannot find a valid baseurl for repo: amzn2-core/2/x86_64
 -  [   50.720504] cloud-init[2255]: Could not retrieve mirrorlist https://amazonlinux-2-repos-us-east-1.s3.dualstack.us-east-1.amazonaws.com/2/core/latest/x86_64/mirror.list error was
 -  [   50.720693] cloud-init[2255]: 12: Timeout on https://amazonlinux-2-repos-us-east-1.s3.dualstack.us-east-1.amazonaws.com/2/core/latest/x86_64/mirror.list: (28, 'Failed to connect to amazonlinux-2-repos-us-east-1.s3.dualstack.us-east-1.amazonaws.com port 443: Connection timed out')
 -  [   50.733678] cloud-init[2255]: Feb 08 14:12:11 cloud-init[2255]: util.py[WARNING]: Failed to install packages: ['docker']
 -  [   51.361199] cloud-init[2461]: Failed to start docker.service: Unit not found.
 -  [   51.372960] cloud-init[2461]: sudo: docker: command not found
 -  [   51.381391] cloud-init[2461]: sudo: docker: command not found
printing out errors faced during the execution:
 -  operation error EC2: TerminateInstances, https response error StatusCode: 403, RequestID: 982a00fd-418c-4462-b643-3b154c0ca0b3, api error UnauthorizedOperation: You are not authorized to perform this operation. Encoded authorization failure message: zeLgvyuENPGak90HsgwgMrWFwSLPmc49fEY_cbGN-YRHlR-uU5RitO5LuvKCwO1lrWQjUHLbYEJudBox68Rn5LREgw7mQidVAdDrDjZ0Sa_BAZEPP83Coh5SuYbKigjMRATSZNIuUVQnfMuGlxvNnkaIMX57DrD0faMd6PAcQVUszpU04S3X3lOhlEEazFPo6MSgQDp-hDHP-EKBObBhU7M9QkY8yv6j7btzMIDjtsnDrcMM1VN5rF4ojs6kmiyAbwpSDS-wI4dzER5gEXeGZ0i7rd7kL8rfzz6l8iJIlTr5dUs_5wCHnJJnaZCA_Yl3Lh3U9BbDTFHOYRrSLyLqghwB_6FL_GrubhxPStdfrE0FyOR-mGCvMIhSOizpsWIUy-8LdDCbww3WhWh3qD72YYtobcxFyt7x3O1UVMiF3WuIVG15mmBrnJuM7x6jpvoE9jvPwe41mhHr2dJFrq_dy7y9RXePXr-f7ovMaWgh_5LM88iEfiQ1ImnVwj9kpWKk-_lEUA5g5bjTBbZ1BzBuSZzMJO8dcA7YpwcQ2233uiazTZH6IHF6Hw1MKnd29VY-oSQLZ4Xby70azIKmyPfpjzJi6cM3cZHjETMlQJS733t6yoehrRLdlRcm2iBtMkZ1g68-ykGwuKeb3sdkm2nZHIRR13rDYjytywOtl--SCpFTqr_xZQFaqxAorw93S--zQjlQGuAoHNig43X6BQoJnISlchCjxhTtaIDx72NdvK-sZhc0-t6nMvC40GgsMfg6C-7-wQU_c2zJl1RfOQUimIRwybVI7E3n1f7oukhnHxrdVT5OV_hqtDuVbG9T
Failure!
```

This PR adds `output` structure that can be used when communicating validation _failures_, _exceptions_, and _errors_ to the upper caller

Main changes:
- `validateEgress()` now returns just output. 
- output and its helper functions (currently attributes of the struct are private but we can expose w/ functions if needed)
- unit test for validateegress
- errors can be gathered under output.errors that'll be printed out in the end, if the error is not fatal