### PR TITLE
Move to net/http connection test

### DIFF
--- a/build/bin/network-validator.go
+++ b/build/bin/network-validator.go
@@ -13,8 +13,6 @@ import (
 	"sync"
 	"time"
 
-	"crypto/tls"
-
 	"golang.org/x/crypto/ssh"
 
 	"gopkg.in/yaml.v2"
@@ -105,9 +103,6 @@ func ValidateReachability(host string, port int) error {
 	endpoint := fmt.Sprintf("%s:%d", host, port)
 	httpClient := http.Client{
 		Timeout: *timeout,
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-		},
 	}
 
 	fmt.Printf("Validating %s\n", endpoint)

--- a/build/bin/network-validator.go
+++ b/build/bin/network-validator.go
@@ -123,7 +123,7 @@ func ValidateReachability(host string, port int) error {
 	}
 
 	if err != nil {
-		return fmt.Errorf("unable to reach %s within specified timeout: %s", endpoint, err)
+		return fmt.Errorf("Unable to reach %s within specified timeout: %s", endpoint, err)
 	}
 
 	return nil

--- a/build/config/config.yaml
+++ b/build/config/config.yaml
@@ -25,6 +25,7 @@ endpoints:
   - host: cert-api.access.redhat.com
     ports:
       - 443
+    tlsDisabled: true
   - host: api.access.redhat.com
     ports:
       - 443

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/openshift-online/ocm-sdk-go v0.1.224
 	github.com/spf13/cobra v1.4.0
 	github.com/spf13/pflag v1.0.5
+	golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e
 	golang.org/x/oauth2 v0.0.0-20210402161424-2e8d93401602
 	google.golang.org/api v0.44.0
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect

--- a/go.sum
+++ b/go.sum
@@ -554,6 +554,7 @@ golang.org/x/crypto v0.0.0-20200323165209-0ec3e9974c59/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201203163018-be400aefbc4c/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
+golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e h1:gsTQYXdTw2Gq7RBsWvlQ91b+aEQ6bXFUngBGuR8sPpI=
 golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -725,6 +726,7 @@ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210831042530-f4d43177bf5e h1:XMgFehsDnnLGtjvjOfqWSUzt0alpTR1RSEuznObga2c=
 golang.org/x/sys v0.0.0-20210831042530-f4d43177bf5e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
+golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 h1:v+OssWQX+hTHEmOBgwxdZxK4zHq3yOs8F9J7mk0PY8E=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/pkg/cloudclient/aws/private.go
+++ b/pkg/cloudclient/aws/private.go
@@ -284,7 +284,7 @@ func generateUserData(variables map[string]string) (string, error) {
 func (c *Client) findUnreachableEndpoints(ctx context.Context, instanceID string) error {
 	// Compile the regular expressions once
 	reVerify := regexp.MustCompile(userdataEndVerifier)
-	reUnreachableErrors := regexp.MustCompile(`Unable to reach (\S+)`)
+	reUnreachableErrors := regexp.MustCompile(`unable to reach (\S+)`)
 
 	latest := true
 	input := ec2.GetConsoleOutputInput{

--- a/pkg/cloudclient/aws/private.go
+++ b/pkg/cloudclient/aws/private.go
@@ -284,7 +284,7 @@ func generateUserData(variables map[string]string) (string, error) {
 func (c *Client) findUnreachableEndpoints(ctx context.Context, instanceID string) error {
 	// Compile the regular expressions once
 	reVerify := regexp.MustCompile(userdataEndVerifier)
-	reUnreachableErrors := regexp.MustCompile(`unable to reach (\S+)`)
+	reUnreachableErrors := regexp.MustCompile(`Unable to reach (\S+)`)
 
 	latest := true
 	input := ec2.GetConsoleOutputInput{


### PR DESCRIPTION
The egress tests currently check if a connection can be established with a specified endpoint. However, with layer 7 packed inspection, the connection is allowed to establish but packets are still filtered. This causes the verifier to show egress urls as reachable when no data is able to pass in cases where layer 7 filtering is used. This PR changes the test to check the response instead of just the connection to more accurately reflect the reachability of the list of urls.

https://issues.redhat.com/browse/OSD-10903