### PR TITLE
Encrypt AWS instance EBS volume by default

### DIFF
--- a/pkg/cloudclient/aws/private.go
+++ b/pkg/cloudclient/aws/private.go
@@ -154,6 +154,16 @@ func (c *Client) createEC2Instance(ctx context.Context, amiID, vpcSubnetID, user
 				SubnetId:                 aws.String(vpcSubnetID),
 			},
 		},
+		// We specify block devices mainly to enable EBS encryption
+		BlockDeviceMappings: []ec2Types.BlockDeviceMapping{
+			{
+				DeviceName: aws.String("/dev/xvda"),
+				Ebs: &ec2Types.EbsBlockDevice{
+					DeleteOnTermination: aws.Bool(true),
+					Encrypted:           aws.Bool(true),
+				},
+			},
+		},
 		UserData:          aws.String(userdata),
 		TagSpecifications: buildTags(c.tags),
 	}


### PR DESCRIPTION
Added a `BlockDeviceMapping` specification to `createEC2Instance()` such that all instances created by the verifier use encrypted EBS volumes by default. Volumes are encrypted with the AWS Managed KMS key and are automatically deleted upon instance termination.

This addresses OSD-10219, where the verifier fails on clusters that mandate encrypted storage universally.