### PR TITLE
feat: use standardized errors for the output

### DIFF
--- a/pkg/cloudclient/aws/private.go
+++ b/pkg/cloudclient/aws/private.go
@@ -19,6 +19,8 @@ import (
 	ocmlog "github.com/openshift-online/ocm-sdk-go/logging"
 	"github.com/openshift/osd-network-verifier/pkg/helpers"
 	"github.com/openshift/osd-network-verifier/pkg/output"
+
+	handledErrors "github.com/openshift/osd-network-verifier/pkg/errors"
 )
 
 var (
@@ -297,7 +299,7 @@ func (c *Client) findUnreachableEndpoints(ctx context.Context, instanceID string
 			notFoundMatch := rgx.FindAllStringSubmatch(string(scriptOutput), -1)
 			if len(notFoundMatch) > 0 {
 				for _, v := range notFoundMatch {
-					c.output.AddException(v[0])
+					c.output.AddException(handledErrors.NewEgressURLError(v[0]))
 				}
 			}
 
@@ -358,25 +360,25 @@ func (c *Client) validateEgress(ctx context.Context, vpcSubnetID, cloudImageID s
 	}
 	userData, err := generateUserData(userDataVariables)
 	if err != nil {
-		return c.output.AddErrorAndReturn(err)
+		return c.output.AddError(err)
 	}
 	c.logger.Debug(ctx, "Base64-encoded generated userdata script:\n---\n%s\n---", userData)
 
 	cloudImageID, err = c.setCloudImage(cloudImageID)
 	if err != nil {
-		return c.output.AddErrorAndReturn(err) // fatal
+		return c.output.AddError(err) // fatal
 	}
 
 	instance, err := c.createEC2Instance(ctx, cloudImageID, vpcSubnetID, userData, instanceCount)
 	if err != nil {
-		return c.output.AddErrorAndReturn(err) // fatal
+		return c.output.AddError(err) // fatal
 	}
 
 	instanceID := *instance.Instances[0].InstanceId
 	c.logger.Debug(ctx, "Waiting for EC2 instance %s to be running", instanceID)
 	if instanceReadyErr := c.waitForEC2InstanceCompletion(ctx, instanceID); instanceReadyErr != nil {
-		c.terminateEC2Instance(ctx, instanceID)             // try to terminate the created instance
-		return c.output.AddErrorAndReturn(instanceReadyErr) // fatal
+		c.terminateEC2Instance(ctx, instanceID)    // try to terminate the created instance
+		return c.output.AddError(instanceReadyErr) // fatal
 	}
 
 	c.logger.Info(ctx, "Gathering and parsing console log output...")

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -1,0 +1,27 @@
+package errors
+
+import "fmt"
+
+type EgressURLError struct {
+	e string
+}
+
+func (e *EgressURLError) Error() string { return e.e }
+
+func NewEgressURLError(failure string) error {
+	return &EgressURLError{
+		e: fmt.Sprintf("egressURL error: %s", failure),
+	}
+}
+
+type GenericError struct {
+	e string
+}
+
+func (e *GenericError) Error() string { return e.e }
+
+func NewGenericError(err error) error {
+	return &GenericError{
+		e: fmt.Sprintf("generic(unhandled) error: %s ", err.Error()),
+	}
+}


### PR DESCRIPTION
Fix: https://issues.redhat.com/browse/OSD-10574

**Example Executions**:

_against a subnet without an igw_

```shell
AWS_ACCESS_KEY_ID=XX AWS_SECRET_ACCESS_KEY=XXX ./osd-network-verifier egress --subnet-id subnet-00370fcf033c27bd8 --region us-east-1
Using region: us-east-1
Created instance with ID: i-00e3fadaefc6342f0
EC2 Instance: i-00e3fadaefc6342f0 Running
Gathering and parsing console log output...
Terminating ec2 instance with id i-00e3fadaefc6342f0
Summary:
printing out failures:
printing out exceptions preventing onv from running:
 -  egressURL error: [   28.639978] cloud-init[2256]: Cannot find a valid baseurl for repo: amzn2-core/2/x86_64
 -  egressURL error: [   28.640090] cloud-init[2256]: Could not retrieve mirrorlist https://amazonlinux-2-repos-us-east-1.s3.dualstack.us-east-1.amazonaws.com/2/core/latest/x86_64/mirror.list error was
 -  egressURL error: [   28.640192] cloud-init[2256]: 12: Timeout on https://amazonlinux-2-repos-us-east-1.s3.dualstack.us-east-1.amazonaws.com/2/core/latest/x86_64/mirror.list: (28, 'Failed to connect to amazonlinux-2-repos-us-east-1.s3.dualstack.us-east-1.amazonaws.com port 443: Connection timed out')
 -  egressURL error: [   48.093067] cloud-init[2256]: Cannot find a valid baseurl for repo: amzn2-core/2/x86_64
 -  egressURL error: [   48.093463] cloud-init[2256]: Could not retrieve mirrorlist https://amazonlinux-2-repos-us-east-1.s3.dualstack.us-east-1.amazonaws.com/2/core/latest/x86_64/mirror.list error was
 -  egressURL error: [   48.093592] cloud-init[2256]: 12: Timeout on https://amazonlinux-2-repos-us-east-1.s3.dualstack.us-east-1.amazonaws.com/2/core/latest/x86_64/mirror.list: (28, 'Failed to connect to amazonlinux-2-repos-us-east-1.s3.dualstack.us-east-1.amazonaws.com port 443: Connection timed out')
 -  egressURL error: [   48.104653] cloud-init[2256]: Apr 08 15:21:55 cloud-init[2256]: util.py[WARNING]: Failed to install packages: ['docker']
 -  egressURL error: [   48.703765] cloud-init[2462]: Failed to start docker.service: Unit not found.
 -  egressURL error: [   48.715777] cloud-init[2462]: sudo: docker: command not found
 -  egressURL error: [   48.724098] cloud-init[2462]: sudo: docker: command not found
printing out errors faced during the execution:
Failure!
```

_validation failure_

```shell
AWS_ACCESS_KEY_ID=XX AWS_SECRET_ACCESS_KEY=XXX ./osd-network-verifier egress --subnet-id subnet-030455abded968aa2 --region us-east-1
Using region: us-east-1
Created instance with ID: i-0dca7346bf3df1ff3
EC2 Instance: i-0dca7346bf3df1ff3 Running
Gathering and parsing console log output...
Terminating ec2 instance with id i-0dca7346bf3df1ff3
Summary:
printing out failures:
 -  egressURL error: Unable to reach nosnch.in:443
printing out exceptions preventing onv from running:
printing out errors faced during the execution:
Failure!
```