### PR TITLE
Allow users to specify instance root volume encryption key

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ cli, err := cloudclient.NewClient(creds, region)
 // ... error checking
 
 // call the validation function and check if it was successful
-out := cli.ValidateEgress(context.TODO(), "vpcSubnetID", "cloudImageID")
+out := cli.ValidateEgress(context.TODO(), "vpcSubnetID", "cloudImageID", "kmsKeyID", 600)
 if !out.IsSuccessful() {
     // Failure
     failures, exceptions, errors := out.Parse()
@@ -71,7 +71,7 @@ region := "us-east-1"
 cli, err := cloudclient.NewClient(*creds, region)
 // ... error checking
 
-out := cli.ValidateEgress(context.TODO(), "vpcSubnetID", "cloudImageID")
+out := cli.ValidateEgress(context.TODO(), "vpcSubnetID", "cloudImageID", "kmsKeyID", 600)
 if !out.IsSuccessful() {
     // Failure
     failures, exceptions, errors := out.Parse()
@@ -102,5 +102,3 @@ AWS_ACCESS_KEY_ID=$(YOUR_AWS_ACCESS_KEY_ID) AWS_SECRET_ACCESS_KEY=$(YOUR_AWS_SEC
 ## Other Subcommands
 
 Take a look at <https://github.com/openshift/osd-network-verifier/tree/main/cmd>
-
-

--- a/cmd/egress/cmd.go
+++ b/cmd/egress/cmd.go
@@ -26,6 +26,7 @@ type egressConfig struct {
 	debug        bool
 	region       string
 	timeout      time.Duration
+	kmsKeyID     string
 }
 
 func getDefaultRegion() string {
@@ -62,7 +63,7 @@ func NewCmdValidateEgress() *cobra.Command {
 				os.Exit(1)
 			}
 
-			out := cli.ValidateEgress(ctx, config.vpcSubnetID, config.cloudImageID, config.timeout)
+			out := cli.ValidateEgress(ctx, config.vpcSubnetID, config.cloudImageID, config.kmsKeyID, config.timeout)
 			out.Summary()
 			if !out.IsSuccessful() {
 				logger.Error(ctx, "Failure!")
@@ -80,6 +81,7 @@ func NewCmdValidateEgress() *cobra.Command {
 	validateEgressCmd.Flags().StringToStringVar(&config.cloudTags, "cloud-tags", defaultTags, "Comma-seperated list of tags to assign to cloud resources")
 	validateEgressCmd.Flags().BoolVar(&config.debug, "debug", false, "If true, enable additional debug-level logging")
 	validateEgressCmd.Flags().DurationVar(&config.timeout, "timeout", 1*time.Second, "Timeout for individual egress validation requests")
+	validateEgressCmd.Flags().StringVar(&config.kmsKeyID, "kms-key-id", "", "ID of KMS key used to encrypt root volumes of created instances. Defaults to cloud account default key")
 
 	validateEgressCmd.MarkFlagRequired("subnet-id")
 

--- a/pkg/cloudclient/aws/aws.go
+++ b/pkg/cloudclient/aws/aws.go
@@ -41,8 +41,8 @@ func (c *Client) ByoVPCValidator(ctx context.Context) error {
 	return nil
 }
 
-func (c *Client) ValidateEgress(ctx context.Context, vpcSubnetID, cloudImageID string, timeout time.Duration) *output.Output {
-	return c.validateEgress(ctx, vpcSubnetID, cloudImageID, timeout)
+func (c *Client) ValidateEgress(ctx context.Context, vpcSubnetID, cloudImageID string, kmsKeyID string, timeout time.Duration) *output.Output {
+	return c.validateEgress(ctx, vpcSubnetID, cloudImageID, kmsKeyID, timeout)
 }
 
 // NewClient creates a new CloudClient for use with AWS.

--- a/pkg/cloudclient/aws/private.go
+++ b/pkg/cloudclient/aws/private.go
@@ -150,21 +150,13 @@ func (c *Client) validateInstanceType(ctx context.Context) error {
 }
 
 func (c *Client) createEC2Instance(ctx context.Context, input createEC2InstanceInput) (ec2.RunInstancesOutput, error) {
+	ebsBlockDevice := &ec2Types.EbsBlockDevice{
+		DeleteOnTermination: aws.Bool(true),
+		Encrypted:           aws.Bool(true),
+	}
 	// Check if KMS key was specified for root volume encryption
-	var ebsBlockDevice *ec2Types.EbsBlockDevice
 	if input.ebsKmsKeyID != "" {
-		// Key specified
-		ebsBlockDevice = &ec2Types.EbsBlockDevice{
-			DeleteOnTermination: aws.Bool(true),
-			Encrypted:           aws.Bool(true),
-			KmsKeyId:            aws.String(input.ebsKmsKeyID),
-		}
-	} else {
-		// Key unspecified
-		ebsBlockDevice = &ec2Types.EbsBlockDevice{
-			DeleteOnTermination: aws.Bool(true),
-			Encrypted:           aws.Bool(true),
-		}
+		ebsBlockDevice.KmsKeyId = aws.String(input.ebsKmsKeyID)
 	}
 
 	// Build our request, converting the go base types into the pointers required by the SDK

--- a/pkg/cloudclient/aws/private.go
+++ b/pkg/cloudclient/aws/private.go
@@ -23,6 +23,14 @@ import (
 	handledErrors "github.com/openshift/osd-network-verifier/pkg/errors"
 )
 
+type createEC2InstanceInput struct {
+	amiID         string
+	vpcSubnetID   string
+	userdata      string
+	ebsKmsKeyID   string
+	instanceCount int
+}
+
 var (
 	instanceCount int = 1
 	defaultAmi        = map[string]string{
@@ -141,32 +149,46 @@ func (c *Client) validateInstanceType(ctx context.Context) error {
 	return nil
 }
 
-func (c *Client) createEC2Instance(ctx context.Context, amiID, vpcSubnetID, userdata string, instanceCount int) (ec2.RunInstancesOutput, error) {
+func (c *Client) createEC2Instance(ctx context.Context, input createEC2InstanceInput) (ec2.RunInstancesOutput, error) {
+	// Check if KMS key was specified for root volume encryption
+	var ebsBlockDevice *ec2Types.EbsBlockDevice
+	if input.ebsKmsKeyID != "" {
+		// Key specified
+		ebsBlockDevice = &ec2Types.EbsBlockDevice{
+			DeleteOnTermination: aws.Bool(true),
+			Encrypted:           aws.Bool(true),
+			KmsKeyId:            aws.String(input.ebsKmsKeyID),
+		}
+	} else {
+		// Key unspecified
+		ebsBlockDevice = &ec2Types.EbsBlockDevice{
+			DeleteOnTermination: aws.Bool(true),
+			Encrypted:           aws.Bool(true),
+		}
+	}
+
 	// Build our request, converting the go base types into the pointers required by the SDK
 	instanceReq := ec2.RunInstancesInput{
-		ImageId:      aws.String(amiID),
-		MaxCount:     aws.Int32(int32(instanceCount)),
-		MinCount:     aws.Int32(int32(instanceCount)),
+		ImageId:      aws.String(input.amiID),
+		MaxCount:     aws.Int32(int32(input.instanceCount)),
+		MinCount:     aws.Int32(int32(input.instanceCount)),
 		InstanceType: ec2Types.InstanceType(c.instanceType),
 		// Because we're making this VPC aware, we also have to include a network interface specification
 		NetworkInterfaces: []ec2Types.InstanceNetworkInterfaceSpecification{
 			{
 				AssociatePublicIpAddress: aws.Bool(true),
 				DeviceIndex:              aws.Int32(0),
-				SubnetId:                 aws.String(vpcSubnetID),
+				SubnetId:                 aws.String(input.vpcSubnetID),
 			},
 		},
 		// We specify block devices mainly to enable EBS encryption
 		BlockDeviceMappings: []ec2Types.BlockDeviceMapping{
 			{
 				DeviceName: aws.String("/dev/xvda"),
-				Ebs: &ec2Types.EbsBlockDevice{
-					DeleteOnTermination: aws.Bool(true),
-					Encrypted:           aws.Bool(true),
-				},
+				Ebs:        ebsBlockDevice,
 			},
 		},
-		UserData:          aws.String(userdata),
+		UserData:          aws.String(input.userdata),
 		TagSpecifications: buildTags(c.tags),
 	}
 	// Finally, we make our request
@@ -356,7 +378,7 @@ func (c *Client) setCloudImage(cloudImageID string) (string, error) {
 // - create instance and wait till it gets ready, wait for userdata script execution
 // - find unreachable endpoints & parse output, then terminate instance
 // - return `c.output` which stores the execution results
-func (c *Client) validateEgress(ctx context.Context, vpcSubnetID, cloudImageID string, timeout time.Duration) *output.Output {
+func (c *Client) validateEgress(ctx context.Context, vpcSubnetID, cloudImageID string, kmsKeyID string, timeout time.Duration) *output.Output {
 	c.logger.Debug(ctx, "Using configured timeout of %s for each egress request", timeout.String())
 	// Generate the userData file
 	userDataVariables := map[string]string{
@@ -379,7 +401,13 @@ func (c *Client) validateEgress(ctx context.Context, vpcSubnetID, cloudImageID s
 		return c.output.AddError(err) // fatal
 	}
 
-	instance, err := c.createEC2Instance(ctx, cloudImageID, vpcSubnetID, userData, instanceCount)
+	instance, err := c.createEC2Instance(ctx, createEC2InstanceInput{
+		amiID:         cloudImageID,
+		vpcSubnetID:   vpcSubnetID,
+		userdata:      userData,
+		ebsKmsKeyID:   kmsKeyID,
+		instanceCount: instanceCount,
+	})
 	if err != nil {
 		return c.output.AddError(err) // fatal
 	}

--- a/pkg/cloudclient/aws/private_test.go
+++ b/pkg/cloudclient/aws/private_test.go
@@ -31,7 +31,11 @@ func TestCreateEC2Instance(t *testing.T) {
 		ec2Client: FakeEC2Cli,
 		logger:    &logging.GlogLogger{},
 	}
-	out, err := cli.createEC2Instance(context.Background(), "test-ami", "test", "", 1)
+	out, err := cli.createEC2Instance(context.Background(), createEC2InstanceInput{
+		amiID:         "test-ami",
+		vpcSubnetID:   "test",
+		instanceCount: 1,
+	})
 	if err != nil {
 		t.Errorf("instance should be created")
 	}
@@ -80,7 +84,7 @@ func TestValidateEgress(t *testing.T) {
 		logger:    &logging.GlogLogger{},
 	}
 
-	if !cli.validateEgress(context.TODO(), vpcSubnetID, cloudImageID, time.Duration(1*time.Second)).IsSuccessful() {
+	if !cli.validateEgress(context.TODO(), vpcSubnetID, cloudImageID, "", time.Duration(1*time.Second)).IsSuccessful() {
 		t.Errorf("validateEgress(): should pass")
 	}
 }

--- a/pkg/cloudclient/cloudclient.go
+++ b/pkg/cloudclient/cloudclient.go
@@ -25,7 +25,7 @@ type CloudClient interface {
 	// ValidateEgress validates that all required targets are reachable from the vpcsubnet
 	// target URLs: https://docs.openshift.com/rosa/rosa_getting_started/rosa-aws-prereqs.html#osd-aws-privatelink-firewall-prerequisites
 	// Expected return value is *output.Output that's storing failures, exceptions and errors
-	ValidateEgress(ctx context.Context, vpcSubnetID, cloudImageID string, timeout time.Duration) *output.Output
+	ValidateEgress(ctx context.Context, vpcSubnetID, cloudImageID string, kmsKeyID string, timeout time.Duration) *output.Output
 }
 
 func NewClient(ctx context.Context, logger ocmlog.Logger, creds interface{}, region, instanceType string, tags map[string]string) (CloudClient, error) {

--- a/pkg/cloudclient/gcp/gcp.go
+++ b/pkg/cloudclient/gcp/gcp.go
@@ -30,7 +30,7 @@ func (c *Client) ByoVPCValidator(ctx context.Context) error {
 	return nil
 }
 
-func (c *Client) ValidateEgress(ctx context.Context, vpcSubnetID, cloudImageID string, timeout time.Duration) *output.Output {
+func (c *Client) ValidateEgress(ctx context.Context, vpcSubnetID, cloudImageID string, kmsKeyID string, timeout time.Duration) *output.Output {
 	return &c.output
 }
 

--- a/pkg/cloudclient/gcp/gcp_test.go
+++ b/pkg/cloudclient/gcp/gcp_test.go
@@ -25,7 +25,7 @@ func TestValidateEgress(t *testing.T) {
 	cloudImageID := "image-id"
 	cli := Client{}
 	timeout := 1 * time.Second
-	if !cli.ValidateEgress(ctx, subnetID, cloudImageID, timeout).IsSuccessful() {
+	if !cli.ValidateEgress(ctx, subnetID, cloudImageID, "", timeout).IsSuccessful() {
 		t.Errorf("validation should have been successful")
 	}
 }


### PR DESCRIPTION
Added a `--kms-key-id <string>` CLI flag that allows the user to specify which KMS key should be used when encrypting the root volume of ONV-created instances. This option has also been added as a parameter (`kmsKeyID`) to the `ValidateEgress()` API function. Not specifying this key simply defaults back to the cloud account default KMS key.

Implementation-wise, adding this option as yet-another parameter to `createEC2Instance()` would have made that function's signature unreadably long, so I instead refactored the function such that it now takes in a param struct of type createEC2InstanceInput.

This addresses OSD-11084, where verifier users requested the ability to specify which KMS key is used for encryption.