### PR TITLE
converting  VPC verification related instances of "validate" to "verify"  

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # binaries
 osd-network-verifier
-network-validator
+network-verifier
 
 # ide
 .vscode/

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -19,11 +19,11 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal:latest AS builder
 WORKDIR /app
 COPY --from=golang /golang/go /usr/local
 COPY . .
-RUN pushd bin; go mod init validator; go get ./...; go build network-validator.go; popd;
+RUN pushd bin; go mod init verifier; go get ./...; go build network-verifier.go; popd;
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 WORKDIR /app
-COPY --from=builder /app/bin/network-validator /usr/bin/network-validator
+COPY --from=builder /app/bin/network-verifier /usr/bin/network-verifier
 COPY --from=builder /app/config/ /app/config/
 
-ENTRYPOINT ["network-validator", "--config=/app/config/config.yaml"]
+ENTRYPOINT ["network-verifier", "--config=/app/config/config.yaml"]

--- a/build/bin/network-verifier.go
+++ b/build/bin/network-verifier.go
@@ -1,7 +1,7 @@
 package main
 
 // Usage
-// $ network-validator --timeout=1s --config=config/config.yaml
+// $ network-verifier --timeout=1s --config=config/config.yaml
 
 import (
 	"flag"
@@ -58,7 +58,7 @@ func main() {
 
 func TestEndpoints(config reachabilityConfig) {
 	// TODO how would we check for wildcard entries like the `.quay.io` entry, where we
-	// need to validate any CDN such as `cdn01.quay.io` should be available?
+	// need to verify any CDN such as `cdn01.quay.io` should be available?
 	//  We don't need to. We just best-effort check what we can.
 
 	var waitGroup sync.WaitGroup
@@ -67,10 +67,10 @@ func TestEndpoints(config reachabilityConfig) {
 	for _, e := range config.Endpoints {
 		for _, port := range e.Ports {
 			waitGroup.Add(1)
-			// Validate the endpoints in parallel
+			// Verify the endpoints in parallel
 			go func(host string, port int, failures chan<- error) {
 				defer waitGroup.Done()
-				err := ValidateReachability(host, port)
+				err := VerifyReachability(host, port)
 				if err != nil {
 					failures <- err
 				}
@@ -95,9 +95,9 @@ func TestEndpoints(config reachabilityConfig) {
 	os.Exit(0)
 }
 
-func ValidateReachability(host string, port int) error {
+func VerifyReachability(host string, port int) error {
 	endpoint := fmt.Sprintf("%s:%d", host, port)
-	fmt.Printf("Validating %s\n", endpoint)
+	fmt.Printf("Verifying %s\n", endpoint)
 	_, err := net.DialTimeout("tcp", endpoint, *timeout)
 	if err != nil {
 		return fmt.Errorf("Unable to reach %s within specified timeout: %s", endpoint, err)

--- a/cmd/byovpc/cmd.go
+++ b/cmd/byovpc/cmd.go
@@ -15,7 +15,8 @@ var debug bool
 
 func NewCmdByovpc() *cobra.Command {
 	byovpcCmd := &cobra.Command{
-		Use: "byovpc",
+		Use:   "byovpc",
+		Short: "Verify given VPC configuration",
 		Run: func(cmd *cobra.Command, args []string) {
 			// Create logger
 			builder := ocmlog.NewStdLoggerBuilder()
@@ -37,7 +38,7 @@ func NewCmdByovpc() *cobra.Command {
 
 			cli, err := cloudclient.NewClient(ctx, logger, creds, region, instanceType, tags)
 
-			err = cli.ByoVPCValidator(ctx)
+			err = cli.ByoVPCVerifier(ctx)
 			if err != nil {
 				logger.Error(ctx, err.Error())
 				os.Exit(1)

--- a/cmd/egress/cmd.go
+++ b/cmd/egress/cmd.go
@@ -37,10 +37,10 @@ func getDefaultRegion() string {
 		return regionDefault
 	}
 }
-func NewCmdValidateEgress() *cobra.Command {
+func NewCmdVerifyEgress() *cobra.Command {
 	config := egressConfig{}
 
-	validateEgressCmd := &cobra.Command{
+	verifyEgressCmd := &cobra.Command{
 		Use: "egress",
 		Run: func(cmd *cobra.Command, args []string) {
 			// ctx
@@ -63,7 +63,7 @@ func NewCmdValidateEgress() *cobra.Command {
 				os.Exit(1)
 			}
 
-			out := cli.ValidateEgress(ctx, config.vpcSubnetID, config.cloudImageID, config.kmsKeyID, config.timeout)
+			out := cli.VerifyEgress(ctx, config.vpcSubnetID, config.cloudImageID, config.kmsKeyID, config.timeout)
 			out.Summary()
 			if !out.IsSuccessful() {
 				logger.Error(ctx, "Failure!")
@@ -74,17 +74,17 @@ func NewCmdValidateEgress() *cobra.Command {
 		},
 	}
 
-	validateEgressCmd.Flags().StringVar(&config.vpcSubnetID, "subnet-id", "", "ID of the source subnet")
-	validateEgressCmd.Flags().StringVar(&config.cloudImageID, "image-id", "", "ID of cloud image")
-	validateEgressCmd.Flags().StringVar(&config.instanceType, "instance-type", "t3.micro", "Instance type of the compute instance egress tests are run from")
-	validateEgressCmd.Flags().StringVar(&config.region, "region", getDefaultRegion(), fmt.Sprintf("Region to validate. Defaults to exported var %[1]v or '%[2]v' if not %[1]v set", regionEnvVarStr, regionDefault))
-	validateEgressCmd.Flags().StringToStringVar(&config.cloudTags, "cloud-tags", defaultTags, "Comma-seperated list of tags to assign to cloud resources")
-	validateEgressCmd.Flags().BoolVar(&config.debug, "debug", false, "If true, enable additional debug-level logging")
-	validateEgressCmd.Flags().DurationVar(&config.timeout, "timeout", 1*time.Second, "Timeout for individual egress validation requests")
-	validateEgressCmd.Flags().StringVar(&config.kmsKeyID, "kms-key-id", "", "ID of KMS key used to encrypt root volumes of created instances. Defaults to cloud account default key")
+	verifyEgressCmd.Flags().StringVar(&config.vpcSubnetID, "subnet-id", "", "ID of the source subnet")
+	verifyEgressCmd.Flags().StringVar(&config.cloudImageID, "image-id", "", "ID of cloud image")
+	verifyEgressCmd.Flags().StringVar(&config.instanceType, "instance-type", "t3.micro", "Instance type of the compute instance egress tests are run from")
+	verifyEgressCmd.Flags().StringVar(&config.region, "region", getDefaultRegion(), fmt.Sprintf("Region to validate. Defaults to exported var %[1]v or '%[2]v' if not %[1]v set", regionEnvVarStr, regionDefault))
+	verifyEgressCmd.Flags().StringToStringVar(&config.cloudTags, "cloud-tags", defaultTags, "Comma-seperated list of tags to assign to cloud resources")
+	verifyEgressCmd.Flags().BoolVar(&config.debug, "debug", false, "If true, enable additional debug-level logging")
+	verifyEgressCmd.Flags().DurationVar(&config.timeout, "timeout", 1*time.Second, "Timeout for individual egress validation requests")
+	verifyEgressCmd.Flags().StringVar(&config.kmsKeyID, "kms-key-id", "", "ID of KMS key used to encrypt root volumes of created instances. Defaults to cloud account default key")
 
-	validateEgressCmd.MarkFlagRequired("subnet-id")
+	verifyEgressCmd.MarkFlagRequired("subnet-id")
 
-	return validateEgressCmd
+	return verifyEgressCmd
 
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -30,7 +30,7 @@ func NewCmdRoot() *cobra.Command {
 
 	// add sub commands
 	rootCmd.AddCommand(byovpc.NewCmdByovpc())
-	rootCmd.AddCommand(egress.NewCmdValidateEgress())
+	rootCmd.AddCommand(egress.NewCmdVerifyEgress())
 
 	return rootCmd
 }

--- a/pkg/cloudclient/aws/aws.go
+++ b/pkg/cloudclient/aws/aws.go
@@ -36,13 +36,13 @@ type EC2Client interface {
 	TerminateInstances(ctx context.Context, input *ec2.TerminateInstancesInput, optFns ...func(*ec2.Options)) (*ec2.TerminateInstancesOutput, error)
 }
 
-func (c *Client) ByoVPCValidator(ctx context.Context) error {
+func (c *Client) ByoVPCVerifier(ctx context.Context) error {
 	c.logger.Info(ctx, "interface executed: %s", ClientIdentifier)
 	return nil
 }
 
-func (c *Client) ValidateEgress(ctx context.Context, vpcSubnetID, cloudImageID string, kmsKeyID string, timeout time.Duration) *output.Output {
-	return c.validateEgress(ctx, vpcSubnetID, cloudImageID, kmsKeyID, timeout)
+func (c *Client) VerifyEgress(ctx context.Context, vpcSubnetID, cloudImageID string, kmsKeyID string, timeout time.Duration) *output.Output {
+	return c.verifyEgress(ctx, vpcSubnetID, cloudImageID, kmsKeyID, timeout)
 }
 
 // NewClient creates a new CloudClient for use with AWS.

--- a/pkg/cloudclient/aws/private_test.go
+++ b/pkg/cloudclient/aws/private_test.go
@@ -45,7 +45,7 @@ func TestCreateEC2Instance(t *testing.T) {
 	}
 }
 
-func TestValidateEgress(t *testing.T) {
+func TestVerifyEgress(t *testing.T) {
 	testID := "aws-docs-example-instanceID"
 	vpcSubnetID, cloudImageID := "dummy-id", "dummy-id"
 	consoleOut := `[   48.062407] cloud-init[2472]: Cloud-init v. 19.3-44.amzn2 running 'modules:final' at Mon, 07 Feb 2022 12:30:22 +0000. Up 48.00 seconds.
@@ -84,7 +84,7 @@ func TestValidateEgress(t *testing.T) {
 		logger:    &logging.GlogLogger{},
 	}
 
-	if !cli.validateEgress(context.TODO(), vpcSubnetID, cloudImageID, "", time.Duration(1*time.Second)).IsSuccessful() {
-		t.Errorf("validateEgress(): should pass")
+	if !cli.verifyEgress(context.TODO(), vpcSubnetID, cloudImageID, "", time.Duration(1*time.Second)).IsSuccessful() {
+		t.Errorf("verifyEgress(): should pass")
 	}
 }

--- a/pkg/cloudclient/cloudclient.go
+++ b/pkg/cloudclient/cloudclient.go
@@ -19,13 +19,13 @@ import (
 // For mocking: mockgen -source=pkg/cloudclient/cloudclient.go -package mocks -destination=pkg/cloudclient/mocks/mock_cloudclient.go
 type CloudClient interface {
 
-	// ByoVPCValidator validates the configuration given by the customer
-	ByoVPCValidator(ctx context.Context) error
+	// ByoVPCVerifier verifies the configuration given by the customer
+	ByoVPCVerifier(ctx context.Context) error
 
-	// ValidateEgress validates that all required targets are reachable from the vpcsubnet
+	// VerifyEgress verifies that all required targets are reachable from the vpcsubnet
 	// target URLs: https://docs.openshift.com/rosa/rosa_getting_started/rosa-aws-prereqs.html#osd-aws-privatelink-firewall-prerequisites
 	// Expected return value is *output.Output that's storing failures, exceptions and errors
-	ValidateEgress(ctx context.Context, vpcSubnetID, cloudImageID string, kmsKeyID string, timeout time.Duration) *output.Output
+	VerifyEgress(ctx context.Context, vpcSubnetID, cloudImageID string, kmsKeyID string, timeout time.Duration) *output.Output
 }
 
 func NewClient(ctx context.Context, logger ocmlog.Logger, creds interface{}, region, instanceType string, tags map[string]string) (CloudClient, error) {

--- a/pkg/cloudclient/gcp/gcp.go
+++ b/pkg/cloudclient/gcp/gcp.go
@@ -25,12 +25,12 @@ type Client struct {
 	output         output.Output
 }
 
-func (c *Client) ByoVPCValidator(ctx context.Context) error {
+func (c *Client) ByoVPCVerifier(ctx context.Context) error {
 	c.logger.Info(ctx, "interface executed: %s", ClientIdentifier)
 	return nil
 }
 
-func (c *Client) ValidateEgress(ctx context.Context, vpcSubnetID, cloudImageID string, kmsKeyID string, timeout time.Duration) *output.Output {
+func (c *Client) VerifyEgress(ctx context.Context, vpcSubnetID, cloudImageID string, kmsKeyID string, timeout time.Duration) *output.Output {
 	return &c.output
 }
 

--- a/pkg/cloudclient/gcp/gcp_test.go
+++ b/pkg/cloudclient/gcp/gcp_test.go
@@ -9,24 +9,24 @@ import (
 	"golang.org/x/oauth2/google"
 )
 
-func TestByoVPCValidator(t *testing.T) {
+func TestByoVPCVerifier(t *testing.T) {
 	ctx := context.TODO()
 	logger := &ocmlog.StdLogger{}
 	client := &Client{logger: logger}
-	err := client.ByoVPCValidator(ctx)
+	err := client.ByoVPCVerifier(ctx)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 }
 
-func TestValidateEgress(t *testing.T) {
+func TestVerifyEgress(t *testing.T) {
 	ctx := context.TODO()
 	subnetID := "subnet-id"
 	cloudImageID := "image-id"
 	cli := Client{}
 	timeout := 1 * time.Second
-	if !cli.ValidateEgress(ctx, subnetID, cloudImageID, "", timeout).IsSuccessful() {
-		t.Errorf("validation should have been successful")
+	if !cli.VerifyEgress(ctx, subnetID, cloudImageID, "", timeout).IsSuccessful() {
+		t.Errorf("verification should have been successful")
 	}
 }
 

--- a/pkg/cloudclient/mocks/mock_cloudclient.go
+++ b/pkg/cloudclient/mocks/mock_cloudclient.go
@@ -34,30 +34,30 @@ func (m *MockCloudClient) EXPECT() *MockCloudClientMockRecorder {
 	return m.recorder
 }
 
-// ByoVPCValidator mocks base method.
-func (m *MockCloudClient) ByoVPCValidator(ctx context.Context) error {
+// ByoVPCVerifier mocks base method.
+func (m *MockCloudClient) ByoVPCVerifier(ctx context.Context) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ByoVPCValidator", ctx)
+	ret := m.ctrl.Call(m, "ByoVPCVerifier", ctx)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// ByoVPCValidator indicates an expected call of ByoVPCValidator.
-func (mr *MockCloudClientMockRecorder) ByoVPCValidator(ctx interface{}) *gomock.Call {
+// ByoVPCVerifier indicates an expected call of ByoVPCVerifier.
+func (mr *MockCloudClientMockRecorder) ByoVPCVerifier(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ByoVPCValidator", reflect.TypeOf((*MockCloudClient)(nil).ByoVPCValidator), ctx)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ByoVPCVerifier", reflect.TypeOf((*MockCloudClient)(nil).ByoVPCVerifier), ctx)
 }
 
-// ValidateEgress mocks base method.
-func (m *MockCloudClient) ValidateEgress(ctx context.Context, vpcSubnetID, cloudImageID string) error {
+// VerifyEgress mocks base method.
+func (m *MockCloudClient) VerifyEgress(ctx context.Context, vpcSubnetID, cloudImageID string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ValidateEgress", ctx, vpcSubnetID, cloudImageID)
+	ret := m.ctrl.Call(m, "VerifyEgress", ctx, vpcSubnetID, cloudImageID)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// ValidateEgress indicates an expected call of ValidateEgress.
-func (mr *MockCloudClientMockRecorder) ValidateEgress(ctx, vpcSubnetID, cloudImageID interface{}) *gomock.Call {
+// VerifyEgress indicates an expected call of VerifyEgress.
+func (mr *MockCloudClientMockRecorder) VerifyEgress(ctx, vpcSubnetID, cloudImageID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateEgress", reflect.TypeOf((*MockCloudClient)(nil).ValidateEgress), ctx, vpcSubnetID, cloudImageID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyEgress", reflect.TypeOf((*MockCloudClient)(nil).VerifyEgress), ctx, vpcSubnetID, cloudImageID)
 }

--- a/pkg/helpers/config/userdata.yaml
+++ b/pkg/helpers/config/userdata.yaml
@@ -8,7 +8,7 @@ packages:
 runcmd:
   - [ sh, -c, echo "${USERDATA_BEGIN}"]
   - sudo service docker start
-  - [ sh, -c, "sudo docker pull ${VALIDATOR_IMAGE}"]
+  - [ sh, -c, "sudo docker pull ${VERIFIER_IMAGE}"]
   # Use `|| true` to ignore failure exit codes, we want the script to continue either way
-  - [ sh, -c, 'sudo docker run --env "AWS_REGION=${AWS_REGION}" -e "START_VERIFIER=${VALIDATOR_START_VERIFIER}" -e "END_VERIFIER=${VALIDATOR_END_VERIFIER}" ${VALIDATOR_IMAGE} --timeout=${TIMEOUT} || true' ]
+  - [ sh, -c, 'sudo docker run --env "AWS_REGION=${AWS_REGION}" -e "START_VERIFIER=${VERIFIER_START_VERIFIER}" -e "END_VERIFIER=${VERIFIER_END_VERIFIER}" ${VERIFIER_IMAGE} --timeout=${TIMEOUT} || true' ]
   - [ sh, -c, echo "${USERDATA_END}"]

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -6,8 +6,8 @@ import (
 	handledErrors "github.com/openshift/osd-network-verifier/pkg/errors"
 )
 
-// Output can be used when showcasing validation results at the end of the execution.
-// `failures` represents the failed validation tests
+// Output can be used when showcasing verification results at the end of the execution.
+// `failures` represents the failed verification tests
 // `exceptions` is to show edge cases where onv couldn't be ended up as expected
 // `errors` is collection of unhandled errors
 type Output struct {


### PR DESCRIPTION
Found while working on [osd-10346](https://issues.redhat.com//browse/osd-10346):

The code and docs are interchangeably using "verify/verifier" and "validate/validator" without obvious intention. There are a couple of legit uses of  "validate" e.g. "validateInstanceType" (thanks for pointing it out @/Anthony).  For all the rest of the VPC verifications, it makes sense to stick to "verify/verifier" to match the package name.
 

This change converts all VPC verification related instances of "validate/validator" to "verify/verifier"  to match osd-network-verifier tool name references. 