### PR TITLE
feat: mask docker related errors

### DIFF
--- a/pkg/cloudclient/aws/private.go
+++ b/pkg/cloudclient/aws/private.go
@@ -322,9 +322,7 @@ func (c *Client) findUnreachableEndpoints(ctx context.Context, instanceID string
 			var rgx = regexp.MustCompile(`(?m)^(.*Cannot.*)|(.*Could not.*)|(.*Failed.*)|(.*command not found.*)`)
 			notFoundMatch := rgx.FindAllStringSubmatch(string(scriptOutput), -1)
 			if len(notFoundMatch) > 0 {
-				for _, v := range notFoundMatch {
-					c.output.AddException(handledErrors.NewEgressURLError(v[0]))
-				}
+				c.output.AddException(handledErrors.NewEgressURLError("internet connectivity problem: please ensure there's internet access in given vpc subnets"))
 			}
 
 			// If debug logging is enabled, output the full console log that appears to include the full userdata run


### PR DESCRIPTION
Second Fix: https://issues.redhat.com/browse/OSD-10574

**Example Executions:**

```shell
AWS_ACCESS_KEY_ID=XXX AWS_SECRET_ACCESS_KEY=XXX ./osd-network-verifier egress --subnet-id subnet-00370fcf033c27bd8 --region us-east-1
Using region: us-east-1
Created instance with ID: i-0fac8fe720cc59071
EC2 Instance: i-0fac8fe720cc59071 Running
Gathering and parsing console log output...
Terminating ec2 instance with id i-0fac8fe720cc59071
Summary:
printing out failures:
printing out exceptions preventing onv from running:
 -  egressURL error: internet connectivity problem: please ensure there's internet access in given vpc subnets
printing out errors faced during the execution:
Failure!

```