### PR TITLE
Fixing the default make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
+default: build
+
 include boilerplate/generated-includes.mk
 
 SHELL := /usr/bin/env bash
-
-default: build
 
 # Include shared Makefiles
 include project.mk


### PR DESCRIPTION
Having make target before the definition of the default target make it fail, moving the default definition at the top of the Makefile