### PR TITLE
osd-9647 added global urls for tagging and route53 domain service

### DIFF
--- a/build/config/config.yaml
+++ b/build/config/config.yaml
@@ -127,3 +127,9 @@ endpoints:
   - host: events.${AWS_REGION}.amazonaws.com
     ports:
       - 443
+  - host: tagging.us-east-1.amazonaws.com
+    ports:
+      - 443
+  - host: route53domains.us-east-1.amazonaws.com
+    ports:
+      - 443


### PR DESCRIPTION
  [OSD-9647](https://issues.redhat.com/browse/OSD-9647):

Done Criteria:

- Identify global AWS API endpoints with `us-east-1` in the URL
- Add global AWS API endpoints to the list of egress targets

Comment:

- The tagging service url  with `us-east-1` has already been removed from rosa in update, so we shouldn't need that. https://github.com/openshift/rosa/pull/547/commits/f49b5e7bf038df217886c2e46b7d768f3be44845

- I also added `route53domains.us-east-1.amazonaws.com` . That's the only service we might need that has a global URL . Reference: https://docs.aws.amazon.com/general/latest/gr/r53.html 

- I didn't find any global URLs used for IAM service. 