### PR TITLE
Use AWS_REGION instead of AWS_DEFAULT_REGION

### DIFF
--- a/cmd/byovpc/cmd.go
+++ b/cmd/byovpc/cmd.go
@@ -31,7 +31,7 @@ func NewCmdByovpc() *cobra.Command {
 			creds := credentials.NewStaticCredentialsProvider(os.Getenv("AWS_ACCESS_KEY_ID"), os.Getenv("AWS_SECRET_ACCESS_KEY"), os.Getenv("AWS_SESSION_TOKEN"))
 
 			// TODO when this command is actually used, most if not all of the following should be command line options
-			region := os.Getenv("AWS_DEFAULT_REGION")
+			region := os.Getenv("AWS_REGION")
 			instanceType := "t3.micro"
 			tags := map[string]string{}
 

--- a/cmd/egress/cmd.go
+++ b/cmd/egress/cmd.go
@@ -14,7 +14,7 @@ import (
 
 var (
 	defaultTags            = map[string]string{"osd-network-verifier": "owned", "red-hat-managed": "true", "Name": "osd-network-verifier"}
-	regionEnvVarStr string = "AWS_DEFAULT_REGION"
+	regionEnvVarStr string = "AWS_REGION"
 	regionDefault   string = "us-east-2"
 )
 


### PR DESCRIPTION
AWS_DEFAULT_REGION is specific to cli configuration, whereas
AWS_REGION is SDK compatible and takes precedent. Given the verifier
utilizes the SDK, AWS_REGION should be used.

Ref: https://issues.redhat.com/browse/OSD-11348