### PR TITLE
Removing cert-api.access.redhat.com from validator config

### DIFF
--- a/build/config/config.yaml
+++ b/build/config/config.yaml
@@ -22,9 +22,6 @@ endpoints:
   - host: quay-registry.s3.amazonaws.com
     ports:
       - 443
-  - host: cert-api.access.redhat.com
-    ports:
-      - 443
   - host: api.access.redhat.com
     ports:
       - 443


### PR DESCRIPTION
This url is not listed in the documentation as a required egress point [1], and causes issues with PR #50. Removing as its not required. 

[1] https://deploy-preview-32552--osdocs.netlify.app/openshift-rosa/latest/rosa_getting_started/rosa-aws-prereqs.html#osd-aws-privatelink-firewall-prerequisites