### PR TITLE
OSD-11009: make test time out error pre-defined instead of generic

### DIFF
--- a/pkg/cloudclient/aws/private.go
+++ b/pkg/cloudclient/aws/private.go
@@ -293,7 +293,8 @@ func (c *Client) findUnreachableEndpoints(ctx context.Context, instanceID string
 	}
 
 	// getConsoleOutput then parse, use c.output to store result of the execution
-	err := helpers.PollImmediate(30*time.Second, 2*time.Minute, func() (bool, error) {
+	// err := helpers.PollImmediate(30*time.Second, 2*time.Minute, func() (bool, error) {
+	err := helpers.PollImmediate(1*time.Microsecond, 2*time.Microsecond, func() (bool, error) {
 		output, err := c.ec2Client.GetConsoleOutput(ctx, &input)
 		if err == nil && output.Output != nil {
 			// First, gather the ec2 console output
@@ -319,10 +320,10 @@ func (c *Client) findUnreachableEndpoints(ctx context.Context, instanceID string
 			}
 
 			// check output failures, report as exception if they occurred
-			var rgx = regexp.MustCompile(`(?m)^(.*Cannot.*)|(.*Could not.*)|(.*Failed.*)|(.*command not found.*)`)
+			var rgx = regexp.MustCompile(`(?m)^(.*Cannot.*)|(.*Could not.*)|(.*Failed.*)|(.*command not found.*)`) //Help to grep an exceptions
 			notFoundMatch := rgx.FindAllStringSubmatch(string(scriptOutput), -1)
 			if len(notFoundMatch) > 0 {
-				c.output.AddException(handledErrors.NewEgressURLError("internet connectivity problem: please ensure there's internet access in given vpc subnets"))
+				c.output.AddException(handledErrors.NewEgressURLError("internet connectivity problem: please ensure there's internet access in given vpc subnets")) //If exception occured, then throw this error and throw it in the output.
 			}
 
 			// If debug logging is enabled, output the full console log that appears to include the full userdata run
@@ -414,6 +415,7 @@ func (c *Client) validateEgress(ctx context.Context, vpcSubnetID, cloudImageID s
 	if err != nil {
 		c.output.AddError(err)
 	}
+
 	c.terminateEC2Instance(ctx, instanceID)
 
 	return &c.output

--- a/pkg/cloudclient/aws/private.go
+++ b/pkg/cloudclient/aws/private.go
@@ -293,8 +293,7 @@ func (c *Client) findUnreachableEndpoints(ctx context.Context, instanceID string
 	}
 
 	// getConsoleOutput then parse, use c.output to store result of the execution
-	// err := helpers.PollImmediate(30*time.Second, 2*time.Minute, func() (bool, error) {
-	err := helpers.PollImmediate(1*time.Microsecond, 2*time.Microsecond, func() (bool, error) {
+	err := helpers.PollImmediate(30*time.Second, 2*time.Minute, func() (bool, error) {
 		output, err := c.ec2Client.GetConsoleOutput(ctx, &input)
 		if err == nil && output.Output != nil {
 			// First, gather the ec2 console output

--- a/pkg/cloudclient/aws/private.go
+++ b/pkg/cloudclient/aws/private.go
@@ -293,6 +293,7 @@ func (c *Client) findUnreachableEndpoints(ctx context.Context, instanceID string
 	}
 
 	// getConsoleOutput then parse, use c.output to store result of the execution
+	// err := helpers.PollImmediate(1*time.Microsecond, 2*time.Microsecond, func() (bool, error) {
 	err := helpers.PollImmediate(30*time.Second, 2*time.Minute, func() (bool, error) {
 		output, err := c.ec2Client.GetConsoleOutput(ctx, &input)
 		if err == nil && output.Output != nil {

--- a/pkg/cloudclient/aws/private.go
+++ b/pkg/cloudclient/aws/private.go
@@ -293,7 +293,6 @@ func (c *Client) findUnreachableEndpoints(ctx context.Context, instanceID string
 	}
 
 	// getConsoleOutput then parse, use c.output to store result of the execution
-	// err := helpers.PollImmediate(1*time.Microsecond, 2*time.Microsecond, func() (bool, error) {
 	err := helpers.PollImmediate(30*time.Second, 2*time.Minute, func() (bool, error) {
 		output, err := c.ec2Client.GetConsoleOutput(ctx, &input)
 		if err == nil && output.Output != nil {
@@ -320,10 +319,10 @@ func (c *Client) findUnreachableEndpoints(ctx context.Context, instanceID string
 			}
 
 			// check output failures, report as exception if they occurred
-			var rgx = regexp.MustCompile(`(?m)^(.*Cannot.*)|(.*Could not.*)|(.*Failed.*)|(.*command not found.*)`) //Help to grep an exceptions
+			var rgx = regexp.MustCompile(`(?m)^(.*Cannot.*)|(.*Could not.*)|(.*Failed.*)|(.*command not found.*)`)
 			notFoundMatch := rgx.FindAllStringSubmatch(string(scriptOutput), -1)
 			if len(notFoundMatch) > 0 {
-				c.output.AddException(handledErrors.NewEgressURLError("internet connectivity problem: please ensure there's internet access in given vpc subnets")) //If exception occured, then throw this error and throw it in the output.
+				c.output.AddException(handledErrors.NewEgressURLError("internet connectivity problem: please ensure there's internet access in given vpc subnets"))
 			}
 
 			// If debug logging is enabled, output the full console log that appears to include the full userdata run
@@ -415,7 +414,6 @@ func (c *Client) validateEgress(ctx context.Context, vpcSubnetID, cloudImageID s
 	if err != nil {
 		c.output.AddError(err)
 	}
-
 	c.terminateEC2Instance(ctx, instanceID)
 
 	return &c.output

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -1,7 +1,6 @@
 package errors
 
 import (
-	_ "embed"
 	"errors"
 	"fmt"
 )

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 )
 
-// import "fmt"
-
 type EgressURLError struct {
 	e string
 }

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -1,10 +1,20 @@
 package errors
 
-import "fmt"
+import (
+	_ "embed"
+	"errors"
+	"fmt"
+)
+
+// import "fmt"
 
 type EgressURLError struct {
 	e string
 }
+
+var ErrWaitTimeout = errors.New("timed out waiting for the condition")
+
+func (e *GenericError) ErrWaitTimeout() string { return e.e }
 
 func (e *EgressURLError) Error() string { return e.e }
 

--- a/pkg/helpers/helpers.go
+++ b/pkg/helpers/helpers.go
@@ -25,6 +25,5 @@ func PollImmediate(interval time.Duration, timeout time.Duration, condition func
 		time.Sleep(interval)
 		totalTime += interval
 	}
-
 	return errors.ErrWaitTimeout
 }

--- a/pkg/helpers/helpers.go
+++ b/pkg/helpers/helpers.go
@@ -2,14 +2,13 @@ package helpers
 
 import (
 	_ "embed"
-	"errors"
 	"time"
+
+	"github.com/openshift/osd-network-verifier/pkg/errors"
 )
 
 //go:embed config/userdata.yaml
 var UserdataTemplate string
-
-var ErrWaitTimeout = errors.New("timed out waiting for the condition")
 
 func PollImmediate(interval time.Duration, timeout time.Duration, condition func() (bool, error)) error {
 
@@ -27,5 +26,5 @@ func PollImmediate(interval time.Duration, timeout time.Duration, condition func
 		totalTime += interval
 	}
 
-	return ErrWaitTimeout
+	return errors.ErrWaitTimeout
 }


### PR DESCRIPTION
The purpose of this PR was to move the error definition which is mentioned in the helpers.go to errors.go file so, that we can throw a test time out error instead of generic(unhandled) error