### PR TITLE
OSD-9234 - Adding a new make target to validate formating

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,16 @@ build:
 	go mod tidy
 	go build $(GOFLAGS) .
 
+.PHONY: fmt
+fmt:
+	go fmt ./...
+	go mod tidy
+
+.PHONY: check-fmt
+check-fmt: fmt
+	git status --porcelain
+	@(test 0 -eq $$(git status --porcelain | wc -l)) || (echo "Local git checkout is not clean, commit changes and try again." >&2 && exit 1)
+
 .PHONY: test
 test:
 	go test $(GOFLAGS) ./...


### PR DESCRIPTION
Making a new make target to be called by the new step in CI