### PR TITLE
bug: reveal hidden ec2 error: getconsoleoutput

### DIFF
--- a/pkg/cloudclient/aws/private.go
+++ b/pkg/cloudclient/aws/private.go
@@ -282,7 +282,10 @@ func (c *Client) findUnreachableEndpoints(ctx context.Context, instanceID string
 	// getConsoleOutput then parse, use c.output to store result of the execution
 	err := helpers.PollImmediate(30*time.Second, 2*time.Minute, func() (bool, error) {
 		output, err := c.ec2Client.GetConsoleOutput(ctx, &input)
-		if err == nil && output.Output != nil {
+		if err != nil {
+			return false, err
+		}
+		if output.Output != nil {
 			// First, gather the ec2 console output
 			scriptOutput, err := base64.StdEncoding.DecodeString(*output.Output)
 			if err != nil {


### PR DESCRIPTION
with a policy that's missing `getConsoleOutput` perms:
```json
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Sid": "VisualEditor1",
            "Effect": "Allow",
            "Action": "ec2:CreateTags",
            "Resource": "*",
            "Condition": {
                "StringEquals": {
                    "aws:RequestTag/osd-network-verifier": "owned"
                }
            }
        },
        {
            "Sid": "VisualEditor2",
            "Effect": "Allow",
            "Action": [
                "ec2:TerminateInstances",
                "ec2:DescribeInstanceTypes",
                "ec2:RunInstances",
                "ec2:DescribeInstanceStatus"
            ],
            "Resource": "*"
        }
    ]
}
```

**before fix:**
```shell
./osd-network-verifier egress --subnet-id subnet-03146948aeaeb21de --region us-east-1
Using region: us-east-1
Created instance with ID: i-0d9eaab26433d150a
EC2 Instance: i-0d9eaab26433d150a Running
Gathering and parsing console log output...
Terminating ec2 instance with id i-0d9eaab26433d150a
Summary:
printing out failures:
printing out exceptions preventing onv from running:
printing out errors faced during the execution:
 -  generic(unhandled) error: timed out waiting for the condition
Failure!

(after waiting for 2 minutes...)
```

**After fix:**
(immediate action)
```shell
Using region: us-east-1
Created instance with ID: i-077c4bbce0ba64a52
EC2 Instance: i-077c4bbce0ba64a52 Running
Gathering and parsing console log output...
Terminating ec2 instance with id i-077c4bbce0ba64a52
Summary:
printing out failures:
printing out exceptions preventing onv from running:
printing out errors faced during the execution:
 -  generic(unhandled) error: operation error EC2: GetConsoleOutput, https response error StatusCode: 403, RequestID: a3bcb79f-73ac-4ca0-8254-ebb07fed2a27, api error UnauthorizedOperation: You are not authorized to perform this operation. Encoded authorization failure message: OZ9h1R1NPJlQtBEpe2nfEYfG_2ULB9NsYhv-ozngScSZp1V-ttZw97M_rg_K7ZI5mhg_Yw9-5mdstWA0vl3nIoePcN_sCiAhTRAPYjLL8Ao1QYp9iQ6GLwpfEnmf5yg0AlAvCjZ9vjj-QY-xM14oDGzUYq7tHntXxRgiWb1v0IhKu3yGrdFdH2slbqheL4tbxChCx9Kq3-Do-8tm6KA7PxBNfdZ0WFMPaDBA8NsFtyCUGFo6atLS8QK1m9Qx_st0uIYZPRBOh8XRogve7YV2JcUWIqTuzBPfNQNmkzH07DtooYTMXiuxjSXa4vGd_vO3v3--SNWUv1phW6ku4BYwraic4a6oQ4WZOEi4POvrdiRLcJ2-he6JvMwdwhz2_zo1aBoAORfe0WvVj9L56u_zsRYNmrw5kN80PzPKX1SYfa917N4yMUJ_yqOzfvHhGdnsTnMw0X6eOY0Hltxnoh0RmsTWK-6BFJFXRnuXY18xRhCIAGYCEBuG66WZSiM3zZECoYR9FbTxtt8ZfiETPvJ-J57Tv_DG-nW_Ai8l9-AX30i1IjwbweEiNwaKP65J4w6cnwI4tQaEVMmgk_0EBgonjJxDFHkf2TMZgB3hPI2V-QP7qs3U4OyywsfKeo6Ovkrgl0IPzLniV24wDH41WeO6MwUqw0OcbtjBspAktfYlLCN-jHcqjTXlMJhfOqcwlszV00jFGQPeJgpux3RCSm62PT9WcnjGeKEejrtEo7Ha_3hz4S8lmrktEu-RrHzr5jQVusjZYAPkLeMp14y6wWjt88BscIf5OmV6mWC-bS4NUkNm1eOOhwPGwNzVmoMfCJng0WKpIjiIWfHNIVFh2uPWQW-dHv3pHx42Vy4I2RIH9orymv9QR8CVrZQ
Failure!
```

