### PR TITLE
OSD-9234 - Fixing formatting

### DIFF
--- a/cmd/byovpc/cmd.go
+++ b/cmd/byovpc/cmd.go
@@ -15,7 +15,7 @@ var debug bool
 
 func NewCmdByovpc() *cobra.Command {
 	byovpcCmd := &cobra.Command{
-		Use: "byovpc",
+		Use:   "byovpc",
 		Short: "Verify subnet configuration of a specific VPC",
 		Run: func(cmd *cobra.Command, args []string) {
 			// Create logger


### PR DESCRIPTION
As we added formatting checks in CI as part of [OSD-9234](https://issues.redhat.com/browse/OSD-9234) , we need to fix to formatting in order to unblock the CI. 