### PR TITLE
OSD-11306 - Update dockerfile to have a working entrypoint

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -23,7 +23,7 @@ RUN pushd build/bin; go mod init validator; go get ./...; go build network-valid
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 WORKDIR /app
-COPY --from=builder /app/build/bin/network-validator /usr/build/bin/network-validator
+COPY --from=builder /app/build/bin/network-validator /usr/bin/network-validator
 COPY --from=builder /app/build/config/ /app/build/config/
 
 ENTRYPOINT ["network-validator", "--config=/app/build/config/config.yaml"]

--- a/pkg/cloudclient/aws/private.go
+++ b/pkg/cloudclient/aws/private.go
@@ -58,7 +58,7 @@ var (
 		"me-south-1":     "",
 	}
 	// TODO find a location for future docker images
-	networkValidatorImage string = "quay.io/app-sre/osd-network-verifier:v133-83e266c"
+	networkValidatorImage string = "quay.io/app-sre/osd-network-verifier:v0.1.157-047e42c"
 	userdataEndVerifier   string = "USERDATA END"
 )
 


### PR DESCRIPTION
The entrypoint defined in the Dockerfile needs to be in the PATH to be able to behave properly. 