### PR TITLE
Removed dupp in OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -5,7 +5,6 @@ reviewers:
 - tiwillia
 - boranx
 - bng0y
-- robotmaxtron
 - ritmun
 - bdematte
 - abyrne55


### PR DESCRIPTION
While reviewing a PR, I noticed there was a dupp in the OWNERS entry so cleaning it up. 