### PR TITLE
OSD-11859 - Removing SFTP as not Mandatory and removing dupplicated check

### DIFF
--- a/build/config/config.yaml
+++ b/build/config/config.yaml
@@ -38,9 +38,6 @@ endpoints:
   - host: storage.googleapis.com
     ports:
       - 443
-  - host: quay-registry.s3.amazonaws.com
-    ports:
-      - 443
   - host: api.openshift.com
     ports:
       - 443
@@ -77,9 +74,6 @@ endpoints:
   - host: nosnch.in
     ports:
       - 443
-  - host: sftp.access.redhat.com
-    ports:
-      - 22
   - host: inputs1.osdsecuritylogs.splunkcloud.com
     ports:
       - 9997


### PR DESCRIPTION
As part of the issues faced by in Prod when we activated osd-network-verifier, we found that the SFTP access was checked (and blocking is failed) while it is only Recommended in the docs. To align with docs, removing the check.
Reference : [OSD-11859](https://issues.redhat.com/browse/OSD-11859)
In addition, removing dupplicated check for quay-registry.s3.amazonaws.com 