### PR TITLE
OSD-11912 - Remove api.pagerduty.com from checked domains

### DIFF
--- a/build/config/config.yaml
+++ b/build/config/config.yaml
@@ -65,9 +65,6 @@ endpoints:
   - host: sts.amazonaws.com
     ports:
       - 443
-  - host: api.pagerduty.com
-    ports:
-      - 443
   - host: events.pagerduty.com
     ports:
       - 443


### PR DESCRIPTION
api.pagerduty.com is used only for service/account management, and not by the monitoring tools (which are using events.pagerduty.com) so removing it from the domains to be validated. 
Reference : [OSD-11912](https://issues.redhat.com/browse/OSD-11912) 