### PR TITLE
add Profile flag --profile

### DIFF
--- a/cmd/egress/cmd.go
+++ b/cmd/egress/cmd.go
@@ -27,6 +27,7 @@ type egressConfig struct {
 	region       string
 	timeout      time.Duration
 	kmsKeyID     string
+	awsProfile   string
 }
 
 func getDefaultRegion() string {
@@ -62,15 +63,17 @@ are set correctly before execution.
 				fmt.Printf("Unable to build logger: %s\n", err.Error())
 				os.Exit(1)
 			}
-
 			logger.Warn(ctx, "Using region: %s", config.region)
-			creds := credentials.NewStaticCredentialsProvider(os.Getenv("AWS_ACCESS_KEY_ID"), os.Getenv("AWS_SECRET_ACCESS_KEY"), os.Getenv("AWS_SESSION_TOKEN"))
+			var creds interface{}
+			creds = credentials.NewStaticCredentialsProvider(os.Getenv("AWS_ACCESS_KEY_ID"), os.Getenv("AWS_SECRET_ACCESS_KEY"), os.Getenv("AWS_SESSION_TOKEN"))
+			if config.awsProfile != "" {
+				creds = config.awsProfile
+			}
 			cli, err := cloudclient.NewClient(ctx, logger, creds, config.region, config.instanceType, config.cloudTags)
 			if err != nil {
 				logger.Error(ctx, err.Error())
 				os.Exit(1)
 			}
-
 			out := cli.ValidateEgress(ctx, config.vpcSubnetID, config.cloudImageID, config.kmsKeyID, config.timeout)
 			out.Summary()
 			if !out.IsSuccessful() {
@@ -90,6 +93,7 @@ are set correctly before execution.
 	validateEgressCmd.Flags().BoolVar(&config.debug, "debug", false, "(optional) if true, enable additional debug-level logging")
 	validateEgressCmd.Flags().DurationVar(&config.timeout, "timeout", 1*time.Second, "(optional) timeout for individual egress verification requests")
 	validateEgressCmd.Flags().StringVar(&config.kmsKeyID, "kms-key-id", "", "(optional) ID of KMS key used to encrypt root volumes of compute instances. Defaults to cloud account default key")
+	validateEgressCmd.Flags().StringVar(&config.awsProfile, "profile", "", "(optional) AWS profile. If present, any credentials passed with CLI will be ignored.")
 
 	if err := validateEgressCmd.MarkFlagRequired("subnet-id"); err != nil {
 		validateEgressCmd.PrintErr(err)

--- a/pkg/cloudclient/aws/aws.go
+++ b/pkg/cloudclient/aws/aws.go
@@ -53,6 +53,15 @@ func (c *Client) VerifyDns(ctx context.Context, vpcID string) *output.Output {
 // NewClient creates a new CloudClient for use with AWS.
 func NewClient(ctx context.Context, logger ocmlog.Logger, creds interface{}, region, instanceType string, tags map[string]string) (client *Client, err error) {
 	switch c := creds.(type) {
+	case string:
+		client, err = newClientFromProfile(
+			ctx,
+			logger,
+			c,
+			region,
+			instanceType,
+			tags,
+		)
 	case awscredsv1.Credentials:
 		var value awscredsv1.Value
 		if value, err = c.Get(); err == nil {

--- a/pkg/cloudclient/aws/private.go
+++ b/pkg/cloudclient/aws/private.go
@@ -93,6 +93,29 @@ func newClient(ctx context.Context, logger ocmlog.Logger, accessID, accessSecret
 	return c, nil
 }
 
+func newClientFromProfile(ctx context.Context, logger ocmlog.Logger, profile, region, instanceType string, tags map[string]string) (*Client, error) {
+	cfg, err := config.LoadDefaultConfig(ctx,
+		config.WithSharedConfigProfile(profile),
+		config.WithRegion(region),
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	c := &Client{
+		ec2Client:    ec2.NewFromConfig(cfg),
+		region:       region,
+		instanceType: instanceType,
+		tags:         tags,
+		logger:       logger,
+		output:       output.Output{},
+	}
+
+	return c, nil
+
+}
+
 func buildTags(tags map[string]string) []ec2Types.TagSpecification {
 	tagList := []ec2Types.Tag{}
 	for k, v := range tags {

--- a/pkg/cloudclient/cloudclient.go
+++ b/pkg/cloudclient/cloudclient.go
@@ -35,7 +35,7 @@ type CloudClient interface {
 
 func NewClient(ctx context.Context, logger ocmlog.Logger, creds interface{}, region, instanceType string, tags map[string]string) (CloudClient, error) {
 	switch c := creds.(type) {
-	case awscredsv1.Credentials, awscredsv2.StaticCredentialsProvider:
+	case awscredsv1.Credentials, awscredsv2.StaticCredentialsProvider, string:
 		return awsCloudClient.NewClient(ctx, logger, c, region, instanceType, tags)
 	case *google.Credentials:
 		return gcpCloudClient.NewClient(ctx, logger, c, region, instanceType, tags)


### PR DESCRIPTION
instead of passing in credentials as ENV, now sre can use --profile to run the verifier.
related jira card: https://issues.redhat.com/browse/OSD-11580

How to test:
run 'make build'
./osd-network-verifier egress --profile $your-profile --subnet-id $your-subnet --region  $region