### PR TITLE
Updated the userdata template to work properly with custom AMI

### DIFF
--- a/pkg/helpers/config/userdata.yaml
+++ b/pkg/helpers/config/userdata.yaml
@@ -1,14 +1,10 @@
 #cloud-config
 repo_update: true
 package_update: true
-
-packages:
-  - docker 
-
 runcmd:
-  - [ sh, -c, echo "${USERDATA_BEGIN}"]
-  - sudo service docker start
-  - [ sh, -c, "sudo docker pull ${VALIDATOR_IMAGE}"]
+  - echo "${USERDATA_BEGIN}" >> /var/log/userdata-output
+  - sudo docker pull ${VALIDATOR_IMAGE}
   # Use `|| true` to ignore failure exit codes, we want the script to continue either way
-  - [ sh, -c, 'sudo docker run --env "AWS_REGION=${AWS_REGION}" -e "START_VERIFIER=${VALIDATOR_START_VERIFIER}" -e "END_VERIFIER=${VALIDATOR_END_VERIFIER}" ${VALIDATOR_IMAGE} --timeout=${TIMEOUT} || true' ]
-  - [ sh, -c, echo "${USERDATA_END}"]
+  - sudo docker run --env "AWS_REGION=${AWS_REGION}" -e "START_VERIFIER=${VALIDATOR_START_VERIFIER}" -e "END_VERIFIER=${VALIDATOR_END_VERIFIER}" ${VALIDATOR_IMAGE} --timeout=${TIMEOUT}  >> /var/log/userdata-output || true
+  - echo "${USERDATA_END}" >> /var/log/userdata-output
+  - cat /var/log/userdata-output >/dev/console


### PR DESCRIPTION
Few changes to allow proper work of osd-network-verifier with our AMI : 
- could not find a clean way to redirect all outputs to the console (found one requiring bash but could not get the generated usrcmd to not use sh) so staging the outputs to a file and sending it to /dev/console as last step
- removing the start of docker as it is failing on our custom AMI (and faillure is detected as 'not internet connection'). From quick investigations, seems docker is aliased to podman in our AMI (except for systemd entries)