### PR TITLE
added // #nosec for InsecureSkipVerify

### DIFF
--- a/build/bin/network-validator.go
+++ b/build/bin/network-validator.go
@@ -115,6 +115,7 @@ func ValidateReachability(host string, port int, tlsDisabled bool) error {
 		Timeout: *timeout,
 	}
 
+	// #nosec G402 -- Low chance of MITM, as the instance is short-lived, see OHSS-11465
 	if tlsDisabled {
 		httpClient.Transport = &http.Transport{
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},


### PR DESCRIPTION
added #nosec for InsecureSkipVerify to skip this check for the linter as a result of gosec :


test "/home/linnguye/golangci.yml" = "" || test ! -e "/home/linnguye/golangci.yml" || GOLANGCI_LINT_CACHE="/tmp/golangci-cache" golangci-lint run -c "/home/linnguye/golangci.yml" ./...
build/bin/network-validator.go:119:33: G402: TLS InsecureSkipVerify set true. (gosec)
			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
			                        
Justification: Low chance of MITM, as the instance is short-lived
related Jira card: https://issues.redhat.com/browse/OSD-11465