### PR TITLE
updated new quay image

### DIFF
--- a/pkg/cloudclient/aws/private.go
+++ b/pkg/cloudclient/aws/private.go
@@ -58,7 +58,7 @@ var (
 		"me-south-1":     "ami-0483952b6a5997b06",
 	}
 	// TODO find a location for future docker images
-	networkValidatorImage string = "quay.io/app-sre/osd-network-verifier:v0.1.159-9a6e0eb"
+	networkValidatorImage string = "quay.io/app-sre/osd-network-verifier:v0.1.197-16fe250"
 	userdataEndVerifier   string = "USERDATA END"
 )
 


### PR DESCRIPTION
Updated to new Quay image after having removed port 22 test (https://github.com/openshift/osd-network-verifier/pull/117)
as the result of testing golangci gosec lint in osd-network-verifier repo: https://issues.redhat.com/browse/OSD-11465

Testing: make build the binary and tested the verifier with the new quay image. Success.

