### PR TITLE
Add more explicit error messages for generic errors and docker errors

### DIFF
--- a/pkg/cloudclient/aws/private.go
+++ b/pkg/cloudclient/aws/private.go
@@ -322,8 +322,17 @@ func (c *Client) findUnreachableEndpoints(ctx context.Context, instanceID string
 			var rgx = regexp.MustCompile(`(?m)^(.*Cannot.*)|(.*Could not.*)|(.*Failed.*)|(.*command not found.*)`)
 			notFoundMatch := rgx.FindAllStringSubmatch(string(scriptOutput), -1)
 			if len(notFoundMatch) > 0 {
-				c.output.AddException(handledErrors.NewGenericError(
-					"internet connectivity problem: please ensure there's internet access in given vpc subnets"))
+
+				errorMsg := "Generic issue: egress tests were not run due to an uncaught error in setup or execution. Further investigation needed"
+
+				dockerRgx := regexp.MustCompile(`(?m)(docker)`)
+				dockerIssue := dockerRgx.FindAllString(string(scriptOutput), -1)
+				if len(dockerIssue) > 0 {
+					errorMsg = "Docker was unable to install or run. Further investigation needed"
+				}
+				c.output.AddException(handledErrors.NewGenericError(errorMsg))
+				c.output.AddError(handledErrors.NewGenericError(fmt.Sprint(notFoundMatch)))
+				c.logger.Debug(ctx, fmt.Sprint(notFoundMatch))
 			}
 
 			// If debug logging is enabled, output the full console log that appears to include the full userdata run


### PR DESCRIPTION
The verifier currently gives an ambiguous error when a "generic" error happens. This PR adds two things to help clarify how to handle non-test failures:

1. Adds a check to see if the problem is specifically related to docker, and a specific message to indicate what went wrong. Error message is added to the print out.
2. Refines the generic error message to indicate that more investigation is needed as the egress test was not able to run fully. 