### PR TITLE
docs: add PR template for verifier

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,49 @@
+<!-- Type of change
+Please mark this PR with one of the following labels, depending on the scope of your change:
+- Bug
+- Enhancement/Feature
+- Refactoring
+- Tests
+- Configuration
+- Docs
+-->
+
+## What does this PR do? / Related Issues / Jira
+
+<!-- Mandatory
+Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
+-->
+
+## Checklist
+
+<!-- Mandatory
+Add a checklist of things that are required to be reviewed in order to have the PR approved
+
+List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
+-->
+
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] I have made corresponding change to the default configuration files
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] I have tested the functionality against gcp / aws, it doesn't cause any regression
+- [ ] I have added execution results to the PR's readme
+
+## Reviewer's Checklist
+
+<!-- Recommended
+Add a checklist of things that are required to be reviewed in order to have the PR approved
+-->
+- [ ] (This needs to be done after technical review) I've run the branch on my local, verified that the functionality is ok
+
+## How to test this PR locally / Special Instructions
+
+<!-- Recommended
+Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
+-->
+
+## Logs 
+
+<!-- Recommended
+Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
+-->


### PR DESCRIPTION
This adds a by-default PR template that should be welcoming users whenever they create a new PR

Ref: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository