### PR TITLE
docs: fix aws, gcp urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ The recommended workflow of diagnostic use of ONV is shown in the following flow
  
 
 ## Cloud Provider Specific READMEs
--  [AWS](docs/AWS/AWS.md)
--  [GCP](docs/GCP/GCP.md)
+-  [AWS](docs/aws/aws.md)
+-  [GCP](docs/gcp/gcp.md)
 
 
 ## Makefile Targets


### PR DESCRIPTION
Currently, the AWS and GCP docs return 404 as the filenames&folders are lowercase/
this PR updates the doc urls