### PR TITLE
feat: enable proxy verification by bumping up the docker image

### DIFF
--- a/pkg/cloudclient/aws/private.go
+++ b/pkg/cloudclient/aws/private.go
@@ -60,7 +60,7 @@ var (
 		"me-south-1":     "ami-0483952b6a5997b06",
 	}
 	// TODO find a location for future docker images
-	networkValidatorImage string = "quay.io/app-sre/osd-network-verifier:v0.1.197-16fe250"
+	networkValidatorImage string = "quay.io/app-sre/osd-network-verifier:v0.1.212-5f88b83"
 	userdataEndVerifier   string = "USERDATA END"
 )
 


### PR DESCRIPTION
## What does this PR do? / Related Issues / Jira

This updates the docker image to the latest as per the index: https://quay.io/repository/app-sre/osd-network-verifier?tab=tags&tag=latest 

The proxy can now be used as the following as it's enabled in the docker-image

```shell
./osd-network-verifier egress --subnet-id subnet-X  --http-proxy http://sre:x@1.2.3.4:8888 --https-proxy https://sre:x@1.2.3.4:8888  --cacert cert.pem --timeout 3s --debug  --profile your-aws-profile --region us-east-1
```

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made the corresponding changes to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have tested the functionality against gcp / aws, it doesn't cause any regression
- [ ] I have added execution results to the PR's readme

## Reviewer's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] (This needs to be done after technical review) I've run the branch on my local, verified that the functionality is ok