### PR TITLE
OSD-13005 Improve debug logging and specificity of returned errors

### DIFF
--- a/cmd/egress/cmd.go
+++ b/cmd/egress/cmd.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"time"
 
@@ -109,7 +108,6 @@ are set correctly before execution.
 					logger.Error(ctx, err.Error())
 					os.Exit(1)
 				}
-
 			} else {
 				// GCP stuff
 				if config.region == "" {
@@ -149,7 +147,7 @@ are set correctly before execution.
 			// Set Up Proxy
 			if config.CaCert != "" {
 				// Read in the cert file
-				cert, err := ioutil.ReadFile(config.CaCert)
+				cert, err := os.ReadFile(config.CaCert)
 				if err != nil {
 					fmt.Println(err)
 					os.Exit(1)

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -8,28 +8,18 @@ import (
 	"github.com/aws/smithy-go"
 )
 
-type EgressURLError struct {
-	e string
-}
-
-var ErrWaitTimeout = errors.New("timed out waiting for the condition")
-
-func (e *GenericError) ErrWaitTimeout() string { return e.message }
-
-func (e *EgressURLError) Error() string { return e.e }
-
-func NewEgressURLError(message string) error {
-	return &EgressURLError{
-		e: fmt.Sprintf("egressURL error: %s", message),
-	}
-}
-
+// GenericError implements the error interface
 type GenericError struct {
 	message string
 }
 
 func (e *GenericError) Error() string { return e.message }
 
+// Ensure GenericError implements the error interface
+var _ error = &GenericError{}
+
+// NewGenericError does some preprocessing if the provided error contains an aws-sdk-go-v2 error, otherwise just
+// prepends `network verifier error: `
 func NewGenericError(err error) *GenericError {
 	var (
 		oe *smithy.OperationError
@@ -65,14 +55,9 @@ func NewGenericError(err error) *GenericError {
 	}
 }
 
-type UnhandledError struct {
-	message string
-}
-
-func (e *UnhandledError) Error() string          { return e.message }
-func (e *UnhandledError) ErrWaitTimeout() string { return e.message }
-func NewGenericUnhandledError(err error) error {
-	return &UnhandledError{
-		message: fmt.Sprintf("generic unhandled error: %s ", err.Error()),
+// NewEgressURLError prepends the provided message with `egressURL error: `
+func NewEgressURLError(message string) error {
+	return &GenericError{
+		message: fmt.Sprintf("egressURL error: %s", message),
 	}
 }

--- a/pkg/helpers/helpers.go
+++ b/pkg/helpers/helpers.go
@@ -2,9 +2,8 @@ package helpers
 
 import (
 	_ "embed"
+	"errors"
 	"time"
-
-	"github.com/openshift/osd-network-verifier/pkg/errors"
 )
 
 //go:embed config/userdata.yaml
@@ -13,7 +12,6 @@ var UserdataTemplate string
 // PollImmediate calls the condition function at the specified interval up to the specified timeout
 // until the condition function returns true or an error
 func PollImmediate(interval time.Duration, timeout time.Duration, condition func() (bool, error)) error {
-
 	var totalTime time.Duration = 0
 
 	for totalTime < timeout {
@@ -29,5 +27,6 @@ func PollImmediate(interval time.Duration, timeout time.Duration, condition func
 		time.Sleep(interval)
 		totalTime += interval
 	}
-	return errors.ErrWaitTimeout
+
+	return errors.New("timed out waiting for the condition")
 }


### PR DESCRIPTION
* Independently check for `enableDnsHostnames` and `enableDnsSupport` and provide errors
* Recommend specifying an image-id when no default image is found
* We're only really aware of docker issues when parsing user data logs at the moment, but setting the code up to expand for future issues
* Consolidated `UnhandledError` (unused) and `EgressURLError` (used once) into `GenericError`
* Add support for the `--profile` flag to the dns subcommand

Sample output:
```
❯ ./osd-network-verifier dns --vpc-id vpc-09206ccf625ee370e --profile=onv
Using region: us-east-2
Using AWS profile: onv
Verifying DNS config for VPC vpc-09206ccf625ee370e
DNS Support for VPC vpc-09206ccf625ee370e: false
DNS Hostnames for VPC vpc-09206ccf625ee370e: true
Summary:
printing out exceptions preventing the verifier from running the specific test:
 -  network verifier error: the enableDnsSupport attribute on VPC: vpc-09206ccf625ee370e is false, must be true
Failure!

❯ ./osd-network-verifier dns --vpc-id vpc-09206ccf625ee370e --profile=onv
Using region: us-east-2
Using AWS profile: onv
Verifying DNS config for VPC vpc-09206ccf625ee370e
DNS Support for VPC vpc-09206ccf625ee370e: true
DNS Hostnames for VPC vpc-09206ccf625ee370e: true
Summary:
All tests pass!
Success
```