### PR TITLE
Break out `ec2:CreateTags` to simplify error handling logic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ build:
 	go build $(GOFLAGS) .
 
 .PHONY: fmt
-fmt:
+fmt: generate
 	go fmt ./...
 	go mod tidy
 
@@ -20,6 +20,12 @@ fmt:
 check-fmt: fmt
 	git status --porcelain
 	@(test 0 -eq $$(git status --porcelain | wc -l)) || (echo "Local git checkout is not clean, commit changes and try again." >&2 && exit 1)
+
+.PHONY: generate
+generate:
+	go install github.com/golang/mock/mockgen@v1.6.0
+	mockgen -source=pkg/cloudclient/aws/aws.go -package mocks -destination=pkg/cloudclient/mocks/mock_aws.go
+	mockgen -source=pkg/cloudclient/cloudclient.go -package mocks -destination=pkg/cloudclient/mocks/mock_cloudclient.go
 
 .PHONY: test
 test:

--- a/pkg/cloudclient/aws/aws.go
+++ b/pkg/cloudclient/aws/aws.go
@@ -30,6 +30,7 @@ type Client struct {
 // to re-generate mockfile once another interface is added for testing:
 // mockgen -source=pkg/cloudclient/aws/aws.go -package mocks -destination=pkg/cloudclient/mocks/mock_aws.go
 type EC2Client interface {
+	CreateTags(ctx context.Context, params *ec2.CreateTagsInput, optFns ...func(*ec2.Options)) (*ec2.CreateTagsOutput, error)
 	RunInstances(ctx context.Context, params *ec2.RunInstancesInput, optFns ...func(*ec2.Options)) (*ec2.RunInstancesOutput, error)
 	DescribeInstanceStatus(ctx context.Context, input *ec2.DescribeInstanceStatusInput, optFns ...func(*ec2.Options)) (*ec2.DescribeInstanceStatusOutput, error)
 	DescribeInstanceTypes(ctx context.Context, input *ec2.DescribeInstanceTypesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeInstanceTypesOutput, error)

--- a/pkg/cloudclient/aws/private_test.go
+++ b/pkg/cloudclient/aws/private_test.go
@@ -34,11 +34,13 @@ func TestCreateEC2Instance(t *testing.T) {
 		}},
 	}, nil)
 
+	FakeEC2Cli.EXPECT().CreateTags(gomock.Any(), gomock.Any()).Times(1).Return(&ec2.CreateTagsOutput{}, nil)
+
 	cli := Client{
 		ec2Client: FakeEC2Cli,
 		logger:    &logging.GlogLogger{},
 	}
-	out, err := cli.createEC2Instance(context.Background(), createEC2InstanceInput{
+	id, err := cli.createEC2Instance(context.Background(), &createEC2InstanceInput{
 		amiID:         "test-ami",
 		vpcSubnetID:   "test",
 		instanceCount: 1,
@@ -47,7 +49,7 @@ func TestCreateEC2Instance(t *testing.T) {
 		t.Errorf("instance should be created")
 	}
 
-	if aws.ToString(out.Instances[0].InstanceId) != testID {
+	if id != testID {
 		t.Errorf("instance ID mismatch")
 	}
 }
@@ -68,6 +70,8 @@ func TestValidateEgress(t *testing.T) {
 			InstanceId: aws.String(testID),
 		}},
 	}, nil)
+
+	FakeEC2Cli.EXPECT().CreateTags(gomock.Any(), gomock.Any()).Times(1).Return(&ec2.CreateTagsOutput{}, nil)
 
 	FakeEC2Cli.EXPECT().DescribeInstanceStatus(gomock.Any(), gomock.Any()).Times(1).Return(&ec2.DescribeInstanceStatusOutput{
 		InstanceStatuses: []types.InstanceStatus{{
@@ -140,6 +144,8 @@ Unable to reach somesample.endpoint
 				InstanceId: aws.String(testID),
 			}},
 		}, nil)
+
+		FakeEC2Cli.EXPECT().CreateTags(gomock.Any(), gomock.Any()).Times(1).Return(&ec2.CreateTagsOutput{}, nil)
 
 		FakeEC2Cli.EXPECT().DescribeInstanceStatus(gomock.Any(), gomock.Any()).Times(1).Return(&ec2.DescribeInstanceStatusOutput{
 			InstanceStatuses: []types.InstanceStatus{{

--- a/pkg/cloudclient/mocks/mock_aws.go
+++ b/pkg/cloudclient/mocks/mock_aws.go
@@ -6,55 +6,56 @@ package mocks
 
 import (
 	context "context"
+	reflect "reflect"
+
 	ec2 "github.com/aws/aws-sdk-go-v2/service/ec2"
 	gomock "github.com/golang/mock/gomock"
-	reflect "reflect"
 )
 
-// MockEC2Client is a mock of EC2Client interface
+// MockEC2Client is a mock of EC2Client interface.
 type MockEC2Client struct {
 	ctrl     *gomock.Controller
 	recorder *MockEC2ClientMockRecorder
 }
 
-// MockEC2ClientMockRecorder is the mock recorder for MockEC2Client
+// MockEC2ClientMockRecorder is the mock recorder for MockEC2Client.
 type MockEC2ClientMockRecorder struct {
 	mock *MockEC2Client
 }
 
-// NewMockEC2Client creates a new mock instance
+// NewMockEC2Client creates a new mock instance.
 func NewMockEC2Client(ctrl *gomock.Controller) *MockEC2Client {
 	mock := &MockEC2Client{ctrl: ctrl}
 	mock.recorder = &MockEC2ClientMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockEC2Client) EXPECT() *MockEC2ClientMockRecorder {
 	return m.recorder
 }
 
-// RunInstances mocks base method
-func (m *MockEC2Client) RunInstances(ctx context.Context, params *ec2.RunInstancesInput, optFns ...func(*ec2.Options)) (*ec2.RunInstancesOutput, error) {
+// CreateTags mocks base method.
+func (m *MockEC2Client) CreateTags(ctx context.Context, params *ec2.CreateTagsInput, optFns ...func(*ec2.Options)) (*ec2.CreateTagsOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{ctx, params}
 	for _, a := range optFns {
 		varargs = append(varargs, a)
 	}
-	ret := m.ctrl.Call(m, "RunInstances", varargs...)
-	ret0, _ := ret[0].(*ec2.RunInstancesOutput)
+	ret := m.ctrl.Call(m, "CreateTags", varargs...)
+	ret0, _ := ret[0].(*ec2.CreateTagsOutput)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// RunInstances indicates an expected call of RunInstances
-func (mr *MockEC2ClientMockRecorder) RunInstances(ctx, params interface{}, optFns ...interface{}) *gomock.Call {
+// CreateTags indicates an expected call of CreateTags.
+func (mr *MockEC2ClientMockRecorder) CreateTags(ctx, params interface{}, optFns ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{ctx, params}, optFns...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunInstances", reflect.TypeOf((*MockEC2Client)(nil).RunInstances), varargs...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTags", reflect.TypeOf((*MockEC2Client)(nil).CreateTags), varargs...)
 }
 
-// DescribeInstanceStatus mocks base method
+// DescribeInstanceStatus mocks base method.
 func (m *MockEC2Client) DescribeInstanceStatus(ctx context.Context, input *ec2.DescribeInstanceStatusInput, optFns ...func(*ec2.Options)) (*ec2.DescribeInstanceStatusOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{ctx, input}
@@ -67,14 +68,14 @@ func (m *MockEC2Client) DescribeInstanceStatus(ctx context.Context, input *ec2.D
 	return ret0, ret1
 }
 
-// DescribeInstanceStatus indicates an expected call of DescribeInstanceStatus
+// DescribeInstanceStatus indicates an expected call of DescribeInstanceStatus.
 func (mr *MockEC2ClientMockRecorder) DescribeInstanceStatus(ctx, input interface{}, optFns ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{ctx, input}, optFns...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeInstanceStatus", reflect.TypeOf((*MockEC2Client)(nil).DescribeInstanceStatus), varargs...)
 }
 
-// DescribeInstanceTypes mocks base method
+// DescribeInstanceTypes mocks base method.
 func (m *MockEC2Client) DescribeInstanceTypes(ctx context.Context, input *ec2.DescribeInstanceTypesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeInstanceTypesOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{ctx, input}
@@ -87,54 +88,14 @@ func (m *MockEC2Client) DescribeInstanceTypes(ctx context.Context, input *ec2.De
 	return ret0, ret1
 }
 
-// DescribeInstanceTypes indicates an expected call of DescribeInstanceTypes
+// DescribeInstanceTypes indicates an expected call of DescribeInstanceTypes.
 func (mr *MockEC2ClientMockRecorder) DescribeInstanceTypes(ctx, input interface{}, optFns ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{ctx, input}, optFns...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeInstanceTypes", reflect.TypeOf((*MockEC2Client)(nil).DescribeInstanceTypes), varargs...)
 }
 
-// GetConsoleOutput mocks base method
-func (m *MockEC2Client) GetConsoleOutput(ctx context.Context, input *ec2.GetConsoleOutputInput, optFns ...func(*ec2.Options)) (*ec2.GetConsoleOutputOutput, error) {
-	m.ctrl.T.Helper()
-	varargs := []interface{}{ctx, input}
-	for _, a := range optFns {
-		varargs = append(varargs, a)
-	}
-	ret := m.ctrl.Call(m, "GetConsoleOutput", varargs...)
-	ret0, _ := ret[0].(*ec2.GetConsoleOutputOutput)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetConsoleOutput indicates an expected call of GetConsoleOutput
-func (mr *MockEC2ClientMockRecorder) GetConsoleOutput(ctx, input interface{}, optFns ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{ctx, input}, optFns...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConsoleOutput", reflect.TypeOf((*MockEC2Client)(nil).GetConsoleOutput), varargs...)
-}
-
-// TerminateInstances mocks base method
-func (m *MockEC2Client) TerminateInstances(ctx context.Context, input *ec2.TerminateInstancesInput, optFns ...func(*ec2.Options)) (*ec2.TerminateInstancesOutput, error) {
-	m.ctrl.T.Helper()
-	varargs := []interface{}{ctx, input}
-	for _, a := range optFns {
-		varargs = append(varargs, a)
-	}
-	ret := m.ctrl.Call(m, "TerminateInstances", varargs...)
-	ret0, _ := ret[0].(*ec2.TerminateInstancesOutput)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// TerminateInstances indicates an expected call of TerminateInstances
-func (mr *MockEC2ClientMockRecorder) TerminateInstances(ctx, input interface{}, optFns ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{ctx, input}, optFns...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TerminateInstances", reflect.TypeOf((*MockEC2Client)(nil).TerminateInstances), varargs...)
-}
-
-// DescribeVpcAttribute mocks base method
+// DescribeVpcAttribute mocks base method.
 func (m *MockEC2Client) DescribeVpcAttribute(ctx context.Context, input *ec2.DescribeVpcAttributeInput, optFns ...func(*ec2.Options)) (*ec2.DescribeVpcAttributeOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{ctx, input}
@@ -147,9 +108,69 @@ func (m *MockEC2Client) DescribeVpcAttribute(ctx context.Context, input *ec2.Des
 	return ret0, ret1
 }
 
-// DescribeVpcAttribute indicates an expected call of DescribeVpcAttribute
+// DescribeVpcAttribute indicates an expected call of DescribeVpcAttribute.
 func (mr *MockEC2ClientMockRecorder) DescribeVpcAttribute(ctx, input interface{}, optFns ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{ctx, input}, optFns...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeVpcAttribute", reflect.TypeOf((*MockEC2Client)(nil).DescribeVpcAttribute), varargs...)
+}
+
+// GetConsoleOutput mocks base method.
+func (m *MockEC2Client) GetConsoleOutput(ctx context.Context, input *ec2.GetConsoleOutputInput, optFns ...func(*ec2.Options)) (*ec2.GetConsoleOutputOutput, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, input}
+	for _, a := range optFns {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "GetConsoleOutput", varargs...)
+	ret0, _ := ret[0].(*ec2.GetConsoleOutputOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetConsoleOutput indicates an expected call of GetConsoleOutput.
+func (mr *MockEC2ClientMockRecorder) GetConsoleOutput(ctx, input interface{}, optFns ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, input}, optFns...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConsoleOutput", reflect.TypeOf((*MockEC2Client)(nil).GetConsoleOutput), varargs...)
+}
+
+// RunInstances mocks base method.
+func (m *MockEC2Client) RunInstances(ctx context.Context, params *ec2.RunInstancesInput, optFns ...func(*ec2.Options)) (*ec2.RunInstancesOutput, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, params}
+	for _, a := range optFns {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "RunInstances", varargs...)
+	ret0, _ := ret[0].(*ec2.RunInstancesOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RunInstances indicates an expected call of RunInstances.
+func (mr *MockEC2ClientMockRecorder) RunInstances(ctx, params interface{}, optFns ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, params}, optFns...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunInstances", reflect.TypeOf((*MockEC2Client)(nil).RunInstances), varargs...)
+}
+
+// TerminateInstances mocks base method.
+func (m *MockEC2Client) TerminateInstances(ctx context.Context, input *ec2.TerminateInstancesInput, optFns ...func(*ec2.Options)) (*ec2.TerminateInstancesOutput, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, input}
+	for _, a := range optFns {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "TerminateInstances", varargs...)
+	ret0, _ := ret[0].(*ec2.TerminateInstancesOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// TerminateInstances indicates an expected call of TerminateInstances.
+func (mr *MockEC2ClientMockRecorder) TerminateInstances(ctx, input interface{}, optFns ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, input}, optFns...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TerminateInstances", reflect.TypeOf((*MockEC2Client)(nil).TerminateInstances), varargs...)
 }

--- a/pkg/cloudclient/mocks/mock_cloudclient.go
+++ b/pkg/cloudclient/mocks/mock_cloudclient.go
@@ -7,8 +7,11 @@ package mocks
 import (
 	context "context"
 	reflect "reflect"
+	time "time"
 
 	gomock "github.com/golang/mock/gomock"
+	output "github.com/openshift/osd-network-verifier/pkg/output"
+	proxy "github.com/openshift/osd-network-verifier/pkg/proxy"
 )
 
 // MockCloudClient is a mock of CloudClient interface.
@@ -49,15 +52,29 @@ func (mr *MockCloudClientMockRecorder) ByoVPCValidator(ctx interface{}) *gomock.
 }
 
 // ValidateEgress mocks base method.
-func (m *MockCloudClient) ValidateEgress(ctx context.Context, vpcSubnetID, cloudImageID string) error {
+func (m *MockCloudClient) ValidateEgress(ctx context.Context, vpcSubnetID, cloudImageID, kmsKeyID string, timeout time.Duration, proxy proxy.ProxyConfig) *output.Output {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ValidateEgress", ctx, vpcSubnetID, cloudImageID)
-	ret0, _ := ret[0].(error)
+	ret := m.ctrl.Call(m, "ValidateEgress", ctx, vpcSubnetID, cloudImageID, kmsKeyID, timeout, proxy)
+	ret0, _ := ret[0].(*output.Output)
 	return ret0
 }
 
 // ValidateEgress indicates an expected call of ValidateEgress.
-func (mr *MockCloudClientMockRecorder) ValidateEgress(ctx, vpcSubnetID, cloudImageID interface{}) *gomock.Call {
+func (mr *MockCloudClientMockRecorder) ValidateEgress(ctx, vpcSubnetID, cloudImageID, kmsKeyID, timeout, proxy interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateEgress", reflect.TypeOf((*MockCloudClient)(nil).ValidateEgress), ctx, vpcSubnetID, cloudImageID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateEgress", reflect.TypeOf((*MockCloudClient)(nil).ValidateEgress), ctx, vpcSubnetID, cloudImageID, kmsKeyID, timeout, proxy)
+}
+
+// VerifyDns mocks base method.
+func (m *MockCloudClient) VerifyDns(ctx context.Context, vpcID string) *output.Output {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "VerifyDns", ctx, vpcID)
+	ret0, _ := ret[0].(*output.Output)
+	return ret0
+}
+
+// VerifyDns indicates an expected call of VerifyDns.
+func (mr *MockCloudClientMockRecorder) VerifyDns(ctx, vpcID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyDns", reflect.TypeOf((*MockCloudClient)(nil).VerifyDns), ctx, vpcID)
 }

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -31,13 +31,6 @@ func NewGenericError(err error) *GenericError {
 		if errors.As(oe.Unwrap(), &ae) {
 			switch {
 			case ae.ErrorCode() == "UnauthorizedOperation":
-				if oe.Service() == "EC2" && oe.Operation() == "RunInstances" {
-					// AWS will return an UnauthorizedOperation for ec2:RunInstances even if the true error is that
-					// it cannot add tags to the instance via ec2:CreateTags
-					return &GenericError{
-						message: fmt.Sprintf("missing required permission(s) %s:%s and/or ec2:CreateTags", strings.ToLower(oe.Service()), oe.Operation()),
-					}
-				}
 				return &GenericError{
 					message: fmt.Sprintf("missing required permission %s:%s", strings.ToLower(oe.Service()), oe.Operation()),
 				}


### PR DESCRIPTION
* I separated applying tags out from the single `ec2:RunInstances` request so that we can give a specific error on a missing `ec2:CreateTags` permission which has the extra benefit of not requiring the end-user to guess which permission is missing. Since we are anticipating tag-based IAM policies, I made sure every time `createEC2Instance` is calls `ec2:RunInstances` and `ec2:CreateTags` in sequence so that this function can be used as-is.
* I also added a `make generate` Makefile target to run `mockgen` and validate it during PR checks