### PR TITLE
Defaulting to prepulled docker image

### DIFF
--- a/pkg/cloudclient/aws/private.go
+++ b/pkg/cloudclient/aws/private.go
@@ -394,6 +394,7 @@ func (c *Client) setCloudImage(cloudImageID string) (string, error) {
 func (c *Client) validateEgress(ctx context.Context, vpcSubnetID, cloudImageID string, kmsKeyID string, timeout time.Duration, p proxy.ProxyConfig) *output.Output {
 	c.logger.Debug(ctx, "Using configured timeout of %s for each egress request", timeout.String())
 	// Generate the userData file
+	// As expand replaces all ${var} (using empty srting for unknown ones), adding the env variables used in userdata.yaml
 	userDataVariables := map[string]string{
 		"AWS_REGION":               c.region,
 		"USERDATA_BEGIN":           "USERDATA BEGIN",
@@ -406,6 +407,8 @@ func (c *Client) validateEgress(ctx context.Context, vpcSubnetID, cloudImageID s
 		"HTTPS_PROXY":              p.HttpsProxy,
 		"CACERT":                   base64.StdEncoding.EncodeToString([]byte(p.Cacert)),
 		"NOTLS":                    strconv.FormatBool(p.NoTls),
+		"IMAGE":                    "$IMAGE",
+		"VALIDATOR_REFERENCE":      "$VALIDATOR_REFERENCE",
 	}
 	userData, err := generateUserData(userDataVariables)
 	if err != nil {

--- a/pkg/helpers/config/userdata.yaml
+++ b/pkg/helpers/config/userdata.yaml
@@ -6,18 +6,22 @@ write_files:
     content: |
       #!/bin/bash
       # based on tls, set up docker run command.
+      echo "${USERDATA_BEGIN}" >> /var/log/userdata-output
+      sudo docker pull ${VALIDATOR_IMAGE} || echo "Warning: could not pull the specified docker image, will try to use the prepulled one" >> /var/log/userdata-output
+      VALIDATOR_REFERENCE=`echo ${VALIDATOR_IMAGE} | cut -d : -f 1`
+      # Retrieving the latest image successfully pulled (either from the script, or prepulled in the AMI)
+      IMAGE=`docker images ${VALIDATOR_REPO} -q  | head -n 2 | tail -n 1`
+      echo "Using IMAGE : $IMAGE" >> /var/log/userdata-output
       if [[ "${CACERT}" != "" ]]; then
         echo "${CACERT}" | base64 --decode > /proxy.pem
-        sudo docker run -v /proxy.pem:/proxy.pem -e "HTTP_PROXY=${HTTP_PROXY}" -e "HTTPS_PROXY=${HTTPS_PROXY}" --env "AWS_REGION=${AWS_REGION}" -e "START_VERIFIER=${VALIDATOR_START_VERIFIER}" -e "END_VERIFIER=${VALIDATOR_END_VERIFIER}" ${VALIDATOR_IMAGE} --timeout=${TIMEOUT} --cacert=/proxy.pem --no-tls=${NOTLS}  >> /var/log/userdata-output || echo "Failed to successfully run the docker container"
+        sudo docker run -v /proxy.pem:/proxy.pem -e "HTTP_PROXY=${HTTP_PROXY}" -e "HTTPS_PROXY=${HTTPS_PROXY}" --env "AWS_REGION=${AWS_REGION}" -e "START_VERIFIER=${VALIDATOR_START_VERIFIER}" -e "END_VERIFIER=${VALIDATOR_END_VERIFIER}" ${IMAGE} --timeout=${TIMEOUT} --cacert=/proxy.pem --no-tls=${NOTLS}  >> /var/log/userdata-output || echo "Failed to successfully run the docker container"
       else
-        sudo docker run --env "AWS_REGION=${AWS_REGION}" -e "HTTP_PROXY=${HTTP_PROXY}" -e "START_VERIFIER=${VALIDATOR_START_VERIFIER}" -e "END_VERIFIER=${VALIDATOR_END_VERIFIER}" ${VALIDATOR_IMAGE} --timeout=${TIMEOUT}  >> /var/log/userdata-output || echo "Failed to successfully run the docker container"
+        sudo docker run --env "AWS_REGION=${AWS_REGION}" -e "HTTP_PROXY=${HTTP_PROXY}" -e "START_VERIFIER=${VALIDATOR_START_VERIFIER}" -e "END_VERIFIER=${VALIDATOR_END_VERIFIER}" ${IMAGE} --timeout=${TIMEOUT}  >> /var/log/userdata-output || echo "Failed to successfully run the docker container"
       fi
+      echo "${USERDATA_END}" >> /var/log/userdata-output
 runcmd:
   - sudo yum upgrade -y 2>1 > /dev/null || echo "Could not update packages"
   - sudo yum install docker -y 2>1 > /dev/null || echo "didn't install docker"
   - sudo service docker start 2>1 > /dev/null || echo "docker not started by systemctl"
-  - echo "${USERDATA_BEGIN}" >> /var/log/userdata-output
-  - sudo docker pull ${VALIDATOR_IMAGE}
   - /run-container.sh
-  - echo "${USERDATA_END}" >> /var/log/userdata-output
   - cat /var/log/userdata-output >/dev/console


### PR DESCRIPTION

<!-- Type of change
Please mark this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement/Feature
- Refactoring
- Tests
- Configuration
- Docs
-->

## What does this PR do? / Related Issues / Jira

In case it is not possible to pull the docker image from requested in osd-network-verifier, trying to default to the image prepulled (present in golden-ami)

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have tested the functionality against gcp / aws, it doesn't cause any regression
- [x] I have added execution results to the PR's readme

## Reviewer's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] (This needs to be done after technical review) I've run the branch on my local, verified that the functionality is ok

## How to test this PR locally / Special Instructions

To test the changes, I temporarily updated the docker image version in private.go to ensure the pull would fail.

## Logs 

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

```
$docker image ls --filter "reference=quay.io/app-sre/osd-network-verifier"
REPOSITORY                             TAG                IMAGE ID       CREATED       SIZE
quay.io/app-sre/osd-network-verifier   v0.1.33-5b7a940    4c6d898e60cc   6 days ago    103MB
quay.io/app-sre/osd-network-verifier   v0.1.212-5f88b83   e4d93a35c482   2 weeks ago   100MB
```
v0.1.33-5b7a940 is the version embedded in the current AMI, v0.1.212-5f88b83 is the current version requested by osd-network-verifier

With default image
```
USERDATA BEGIN
Using IMAGE : e4d93a35c482
```

With modified docker image tag
```
USERDATA BEGIN
Warning: could not pull the specified docker image, will try to use the prepulled one
Using IMAGE : 4c6d898e60cc
```