### PR TITLE
OSD-12354 Add --security-group-id flag to specify one for the ONV EC2 Instance

### DIFF
--- a/cmd/egress/cmd.go
+++ b/cmd/egress/cmd.go
@@ -24,20 +24,21 @@ var (
 )
 
 type egressConfig struct {
-	vpcSubnetID  string
-	cloudImageID string
-	instanceType string
-	cloudTags    map[string]string
-	debug        bool
-	region       string
-	timeout      time.Duration
-	kmsKeyID     string
-	httpProxy    string
-	httpsProxy   string
-	CaCert       string
-	noTls        bool
-	gcp          bool
-	awsProfile   string
+	vpcSubnetID     string
+	cloudImageID    string
+	instanceType    string
+	securityGroupId string
+	cloudTags       map[string]string
+	debug           bool
+	region          string
+	timeout         time.Duration
+	kmsKeyID        string
+	httpProxy       string
+	httpsProxy      string
+	CaCert          string
+	noTls           bool
+	gcp             bool
+	awsProfile      string
 }
 
 func getDefaultRegion(cloudProvider string) string {
@@ -164,7 +165,7 @@ are set correctly before execution.
 				NoTls:      config.noTls,
 			}
 
-			out := cli.ValidateEgress(ctx, config.vpcSubnetID, config.cloudImageID, config.kmsKeyID, config.timeout, p)
+			out := cli.ValidateEgress(ctx, config.vpcSubnetID, config.cloudImageID, config.kmsKeyID, config.securityGroupId, config.timeout, p)
 
 			out.Summary(config.debug)
 			if !out.IsSuccessful() {
@@ -179,6 +180,7 @@ are set correctly before execution.
 	validateEgressCmd.Flags().StringVar(&config.vpcSubnetID, "subnet-id", "", "source subnet ID")
 	validateEgressCmd.Flags().StringVar(&config.cloudImageID, "image-id", "", "(optional) cloud image for the compute instance")
 	validateEgressCmd.Flags().StringVar(&config.instanceType, "instance-type", "", "(optional) compute instance type")
+	validateEgressCmd.Flags().StringVar(&config.securityGroupId, "security-group-id", "", "(optional) security group id to attach to the created EC2 instance")
 	validateEgressCmd.Flags().StringVar(&config.region, "region", "", fmt.Sprintf("(optional) compute instance region. If absent, environment var %[1]v = %[2]v and %[3]v = %[4]v will be used", awsRegionEnvVarStr, awsRegionDefault, gcpRegionEnvVarStr, gcpRegionDefault))
 	validateEgressCmd.Flags().StringToStringVar(&config.cloudTags, "cloud-tags", defaultTags, "(optional) comma-seperated list of tags to assign to cloud resources e.g. --cloud-tags key1=value1,key2=value2")
 	validateEgressCmd.Flags().BoolVar(&config.debug, "debug", false, "(optional) if true, enable additional debug-level logging")

--- a/examples/aws/proxy_enabled.go
+++ b/examples/aws/proxy_enabled.go
@@ -52,7 +52,7 @@ TRVfvGGNFuJkfkh4rR09wHvlmyzSVJ6le6iaQ0wlp2S0j9oC2A==
 	}
 
 	// Call egress validator
-	out := cli.ValidateEgress(context.TODO(), "vpcSubnetID", "cloudImageID", "kmsKeyID", 3*time.Second, p)
+	out := cli.ValidateEgress(context.TODO(), "vpcSubnetID", "cloudImageID", "kmsKeyID", "securityGroupId", 3*time.Second, p)
 	if !out.IsSuccessful() {
 		// Retrieve errors
 		failures, exceptions, errors := out.Parse()

--- a/examples/aws/verify_egressv1.go
+++ b/examples/aws/verify_egressv1.go
@@ -31,7 +31,7 @@ func extendValidateEgressV1() {
 	//---------ONV egress verifier usage---------
 	cli, _ := cloudclient.NewClient(context.TODO(), logger, *creds, region, instanceType, tags)
 	// Call egress validator
-	out := cli.ValidateEgress(context.TODO(), "vpcSubnetID", "cloudImageID", "kmsKeyID", 3*time.Second, proxy.ProxyConfig{})
+	out := cli.ValidateEgress(context.TODO(), "vpcSubnetID", "cloudImageID", "kmsKeyID", "securityGroupId", 3*time.Second, proxy.ProxyConfig{})
 	if !out.IsSuccessful() {
 		// Retrieve errors
 		failures, exceptions, errors := out.Parse()

--- a/examples/aws/verify_egressv2.go
+++ b/examples/aws/verify_egressv2.go
@@ -32,7 +32,7 @@ func extendValidateEgressV2() {
 	//---------ONV egress verifier usage---------
 	cli, _ := cloudclient.NewClient(ctx, logger, creds, region, instanceType, tags)
 	// Call egress validator
-	out := cli.ValidateEgress(context.TODO(), "vpcSubnetID", "cloudImageID", "kmsKeyID", 3*time.Second, proxy.ProxyConfig{})
+	out := cli.ValidateEgress(context.TODO(), "vpcSubnetID", "cloudImageID", "kmsKeyID", "securityGroupId", 3*time.Second, proxy.ProxyConfig{})
 	if !out.IsSuccessful() {
 		// Retrieve errors
 		failures, exceptions, errors := out.Parse()

--- a/pkg/cloudclient/aws/aws.go
+++ b/pkg/cloudclient/aws/aws.go
@@ -44,8 +44,8 @@ func (c *Client) ByoVPCValidator(ctx context.Context) error {
 	return nil
 }
 
-func (c *Client) ValidateEgress(ctx context.Context, vpcSubnetID, cloudImageID string, kmsKeyID string, timeout time.Duration, proxy proxy.ProxyConfig) *output.Output {
-	return c.validateEgress(ctx, vpcSubnetID, cloudImageID, kmsKeyID, timeout, proxy)
+func (c *Client) ValidateEgress(ctx context.Context, vpcSubnetID, cloudImageID, kmsKeyID, securityGroupId string, timeout time.Duration, proxy proxy.ProxyConfig) *output.Output {
+	return c.validateEgress(ctx, vpcSubnetID, cloudImageID, kmsKeyID, securityGroupId, timeout, proxy)
 }
 
 func (c *Client) VerifyDns(ctx context.Context, vpcID string) *output.Output {

--- a/pkg/cloudclient/aws/private_test.go
+++ b/pkg/cloudclient/aws/private_test.go
@@ -41,8 +41,8 @@ func TestCreateEC2Instance(t *testing.T) {
 		logger:    &logging.GlogLogger{},
 	}
 	id, err := cli.createEC2Instance(context.Background(), &createEC2InstanceInput{
-		amiID:         "test-ami",
-		vpcSubnetID:   "test",
+		amiId:         "test-ami",
+		subnetId:      "test",
 		instanceCount: 1,
 	})
 	if err != nil {
@@ -96,7 +96,7 @@ func TestValidateEgress(t *testing.T) {
 		logger:    &logging.GlogLogger{},
 	}
 
-	if !cli.validateEgress(context.TODO(), vpcSubnetID, cloudImageID, "", time.Duration(1*time.Second), proxy.ProxyConfig{}).IsSuccessful() {
+	if !cli.validateEgress(context.TODO(), vpcSubnetID, cloudImageID, "", "", time.Duration(1*time.Second), proxy.ProxyConfig{}).IsSuccessful() {
 		t.Errorf("validateEgress(): should pass")
 	}
 }
@@ -163,7 +163,7 @@ Unable to reach somesample.endpoint
 			ec2Client: FakeEC2Cli,
 			logger:    &logging.GlogLogger{},
 		}
-		if cli.validateEgress(context.TODO(), vpcSubnetID, cloudImageID, "",
+		if cli.validateEgress(context.TODO(), vpcSubnetID, cloudImageID, "", "",
 			time.Duration(1*time.Second), proxy.ProxyConfig{}).IsSuccessful() {
 			t.Errorf("failed %s: validateEgress(): should fail", test.name)
 		}

--- a/pkg/cloudclient/cloudclient.go
+++ b/pkg/cloudclient/cloudclient.go
@@ -19,14 +19,13 @@ import (
 // CloudClient defines the interface for a cloud agnostic implementation
 // For mocking: mockgen -source=pkg/cloudclient/cloudclient.go -package mocks -destination=pkg/cloudclient/mocks/mock_cloudclient.go
 type CloudClient interface {
-
 	// ByoVPCValidator validates the configuration given by the customer
 	ByoVPCValidator(ctx context.Context) error
 
 	// ValidateEgress validates that all required targets are reachable from the vpcsubnet
 	// target URLs: https://docs.openshift.com/rosa/rosa_getting_started/rosa-aws-prereqs.html#osd-aws-privatelink-firewall-prerequisites
 	// Expected return value is *output.Output that's storing failures, exceptions and errors
-	ValidateEgress(ctx context.Context, vpcSubnetID, cloudImageID string, kmsKeyID string, timeout time.Duration, proxy proxy.ProxyConfig) *output.Output
+	ValidateEgress(ctx context.Context, vpcSubnetID, cloudImageID, kmsKeyID, securityGroupId string, timeout time.Duration, proxy proxy.ProxyConfig) *output.Output
 
 	// VerifyDns verifies that a given VPC meets the DNS requirements specified in:
 	// https://docs.openshift.com/container-platform/4.10/installing/installing_aws/installing-aws-vpc.html

--- a/pkg/cloudclient/gcp/gcp.go
+++ b/pkg/cloudclient/gcp/gcp.go
@@ -31,7 +31,7 @@ func (c *Client) ByoVPCValidator(ctx context.Context) error {
 	return nil
 }
 
-func (c *Client) ValidateEgress(ctx context.Context, vpcSubnetID, cloudImageID string, kmsKeyID string, timeout time.Duration, proxy proxy.ProxyConfig) *output.Output {
+func (c *Client) ValidateEgress(ctx context.Context, vpcSubnetID, cloudImageID, kmsKeyID, securityGroupId string, timeout time.Duration, proxy proxy.ProxyConfig) *output.Output {
 	return c.validateEgress(ctx, vpcSubnetID, cloudImageID, kmsKeyID, timeout, proxy)
 }
 

--- a/pkg/cloudclient/gcp/gcp_test.go
+++ b/pkg/cloudclient/gcp/gcp_test.go
@@ -28,7 +28,7 @@ func TestValidateEgress(t *testing.T) {
 	cloudImageID := "image-id"
 	cli := Client{}
 	timeout := 1 * time.Second
-	if !cli.ValidateEgress(ctx, subnetID, cloudImageID, "", timeout, proxy.ProxyConfig{}).IsSuccessful() {
+	if !cli.ValidateEgress(ctx, subnetID, cloudImageID, "", "", timeout, proxy.ProxyConfig{}).IsSuccessful() {
 		t.Errorf("validation should have been successful")
 	}
 }

--- a/pkg/cloudclient/mocks/mock_cloudclient.go
+++ b/pkg/cloudclient/mocks/mock_cloudclient.go
@@ -52,17 +52,17 @@ func (mr *MockCloudClientMockRecorder) ByoVPCValidator(ctx interface{}) *gomock.
 }
 
 // ValidateEgress mocks base method.
-func (m *MockCloudClient) ValidateEgress(ctx context.Context, vpcSubnetID, cloudImageID, kmsKeyID string, timeout time.Duration, proxy proxy.ProxyConfig) *output.Output {
+func (m *MockCloudClient) ValidateEgress(ctx context.Context, vpcSubnetID, cloudImageID, kmsKeyID, securityGroupId string, timeout time.Duration, proxy proxy.ProxyConfig) *output.Output {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ValidateEgress", ctx, vpcSubnetID, cloudImageID, kmsKeyID, timeout, proxy)
+	ret := m.ctrl.Call(m, "ValidateEgress", ctx, vpcSubnetID, cloudImageID, kmsKeyID, securityGroupId, timeout, proxy)
 	ret0, _ := ret[0].(*output.Output)
 	return ret0
 }
 
 // ValidateEgress indicates an expected call of ValidateEgress.
-func (mr *MockCloudClientMockRecorder) ValidateEgress(ctx, vpcSubnetID, cloudImageID, kmsKeyID, timeout, proxy interface{}) *gomock.Call {
+func (mr *MockCloudClientMockRecorder) ValidateEgress(ctx, vpcSubnetID, cloudImageID, kmsKeyID, securityGroupId, timeout, proxy interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateEgress", reflect.TypeOf((*MockCloudClient)(nil).ValidateEgress), ctx, vpcSubnetID, cloudImageID, kmsKeyID, timeout, proxy)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateEgress", reflect.TypeOf((*MockCloudClient)(nil).ValidateEgress), ctx, vpcSubnetID, cloudImageID, kmsKeyID, securityGroupId, timeout, proxy)
 }
 
 // VerifyDns mocks base method.


### PR DESCRIPTION
## What does this PR do?
Added a `--security-group-id` flag so that a specific one can be specified on the CLI.

e.g.

```bash
./osd-network-verifier egress --subnet-id subnet-010292f1964143c8d --security-group-id sg-0ebcec4462fe7e5b7 --profile=onv 
Using AWS profile: onv
Using region: us-east-2
Created instance with ID: i-0aa70edb273d93dd2
EC2 Instance: i-0aa70edb273d93dd2 Running
Terminating ec2 instance with id i-0aa70edb273d93dd2
Summary:
All tests pass!
Success
```