### PR TITLE
Bugfix - correct name tag capitalization

### DIFF
--- a/cmd/egress/cmd.go
+++ b/cmd/egress/cmd.go
@@ -16,7 +16,7 @@ import (
 )
 
 var (
-	defaultTags               = map[string]string{"osd-network-verifier": "owned", "red-hat-managed": "true", "name": "osd-network-verifier"}
+	defaultTags               = map[string]string{"osd-network-verifier": "owned", "red-hat-managed": "true", "Name": "osd-network-verifier"}
 	awsRegionEnvVarStr string = "AWS_REGION"
 	awsRegionDefault   string = "us-east-2"
 	gcpRegionEnvVarStr string = "GCP_REGION"


### PR DESCRIPTION
## What does this PR do? / Related Issues / Jira
On-call ran into this issue: 
`fix for network verifier error: error performing ec2:CreateTags: For 'Name', use the capitalization specified by the tag policy.`

This is due to an AWS tag policy specified by the customer (https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_example-tag-policies.html), but we should use the correct capitalization anyway.