### PR TITLE
Don't interact with yum in userdata

### DIFF
--- a/pkg/helpers/config/userdata.yaml
+++ b/pkg/helpers/config/userdata.yaml
@@ -20,8 +20,6 @@ write_files:
       fi
       echo "${USERDATA_END}" >> /var/log/userdata-output
 runcmd:
-  - sudo yum upgrade -y 2>1 > /dev/null || echo "Could not update packages"
-  - sudo yum install docker -y 2>1 > /dev/null || echo "didn't install docker"
   - sudo service docker start 2>1 > /dev/null || echo "docker not started by systemctl"
   - /run-container.sh
   - cat /var/log/userdata-output >/dev/console


### PR DESCRIPTION
## What does this PR do? / Related Issues / Jira
Running `yum upgrade -y` at provision time can timeout if the customer has blocked that, causing the rest of the userdata script to never run. Since updates and docker are installed at build time within the custom AMI, these can safely be removed from the userdata script.

I tested this by creating a vanilla BYOVPC and editing the private subnet's network ACL to deny 443:

```
1 | HTTPS (443) | TCP (6) | 443 | 0.0.0.0/0 | Deny
```

## Logs 

Before change, the AMI spins and times out without ever starting the network-verifier because yum upgrade is timing out:
```
❯ ./osd-network-verifier egress --subnet-id subnet-01e793940af774542 --region us-east-1
Using region: us-east-1
Created instance with ID: i-0635404f0382ca5f2
EC2 Instance: i-0635404f0382ca5f2 Running
Terminating ec2 instance with id i-0635404f0382ca5f2
Summary:
printing out errors faced during the execution:
 -  network verifier error: timed out waiting for the condition
Failure!
```

After change:
```
❯ ./osd-network-verifier egress --subnet-id subnet-01e793940af774542 --region us-east-1
Using region: us-east-1
Created instance with ID: i-0af0de0ecd5fe021f
EC2 Instance: i-0af0de0ecd5fe021f Running
Terminating ec2 instance with id i-0af0de0ecd5fe021f
Summary:
printing out failures:
 -  egressURL error: Unable to reach quay-registry.s3.amazonaws.com:443
 -  egressURL error: Unable to reach cert-api.access.redhat.com:443
 -  egressURL error: Unable to reach pull.q1w2.quay.rhcloud.com:443
 -  egressURL error: Unable to reach observatorium.api.openshift.com:443
 -  egressURL error: Unable to reach route53domains.us-east-1.amazonaws.com:443
 -  egressURL error: Unable to reach ec2.us-east-1.amazonaws.com:443
 -  egressURL error: Unable to reach sso.redhat.com:80
 -  egressURL error: Unable to reach openshift.org:443
 -  egressURL error: Unable to reach events.us-east-1.amazonaws.com:443
 -  egressURL error: Unable to reach iam.amazonaws.com:443
 -  egressURL error: Unable to reach tagging.us-east-1.amazonaws.com:443
 -  egressURL error: Unable to reach route53.amazonaws.com:443
 -  egressURL error: Unable to reach sts.amazonaws.com:443
 -  egressURL error: Unable to reach ec2.amazonaws.com:443
 -  egressURL error: Unable to reach registry.redhat.io:443
 -  egressURL error: Unable to reach http-inputs-osdsecuritylogs.splunkcloud.com:443
 -  egressURL error: Unable to reach cm-quay-production-s3.s3.amazonaws.com:443
 -  egressURL error: Unable to reach sso.redhat.com:443
 -  egressURL error: Unable to reach infogw.api.openshift.com:443
 -  egressURL error: Unable to reach registry.access.redhat.com:443
 -  egressURL error: Unable to reach api.openshift.com:443
 -  egressURL error: Unable to reach api.access.redhat.com:443
 -  egressURL error: Unable to reach console.redhat.com:443
 -  egressURL error: Unable to reach elasticloadbalancing.us-east-1.amazonaws.com:443
 -  egressURL error: Unable to reach events.pagerduty.com:443
 -  egressURL error: Unable to reach nosnch.in:443
 -  egressURL error: Unable to reach cart-rhcos-ci.s3.amazonaws.com:443
 -  egressURL error: Unable to reach console.redhat.com:80
 -  egressURL error: Unable to reach storage.googleapis.com:443
 -  egressURL error: Unable to reach mirror.openshift.com:443
 -  egressURL error: Unable to reach quay.io:443
 -  egressURL error: Unable to reach api.deadmanssnitch.com:443
Failure!
```