### PR TITLE
OSD-13342 Replace docker with podman

### DIFF
--- a/pkg/helpers/config/userdata.yaml
+++ b/pkg/helpers/config/userdata.yaml
@@ -5,21 +5,19 @@ write_files:
     permissions: 755
     content: |
       #!/bin/bash
-      # based on tls, set up docker run command.
       echo "${USERDATA_BEGIN}" >> /var/log/userdata-output
-      sudo docker pull ${VALIDATOR_IMAGE} || echo "Warning: could not pull the specified docker image, will try to use the prepulled one" >> /var/log/userdata-output
+      podman pull ${VALIDATOR_IMAGE} || echo "Warning: could not pull the specified docker image, will try to use the prepulled one" >> /var/log/userdata-output
       VALIDATOR_REFERENCE=`echo ${VALIDATOR_IMAGE} | cut -d : -f 1`
       # Retrieving the latest image successfully pulled (either from the script, or prepulled in the AMI)
-      IMAGE=`docker images ${VALIDATOR_REPO} -q  | head -n 2 | tail -n 1`
+      IMAGE=`podman images ${VALIDATOR_REPO} -q  | head -n 2 | tail -n 1`
       echo "Using IMAGE : $IMAGE" >> /var/log/userdata-output
       if [[ "${CACERT}" != "" ]]; then
         echo "${CACERT}" | base64 --decode > /proxy.pem
-        sudo docker run -v /proxy.pem:/proxy.pem -e "HTTP_PROXY=${HTTP_PROXY}" -e "HTTPS_PROXY=${HTTPS_PROXY}" --env "AWS_REGION=${AWS_REGION}" -e "START_VERIFIER=${VALIDATOR_START_VERIFIER}" -e "END_VERIFIER=${VALIDATOR_END_VERIFIER}" ${IMAGE} --timeout=${TIMEOUT} --cacert=/proxy.pem --no-tls=${NOTLS}  >> /var/log/userdata-output || echo "Failed to successfully run the docker container"
+        podman run -v /proxy.pem:/proxy.pem -e "HTTP_PROXY=${HTTP_PROXY}" -e "HTTPS_PROXY=${HTTPS_PROXY}" --env "AWS_REGION=${AWS_REGION}" -e "START_VERIFIER=${VALIDATOR_START_VERIFIER}" -e "END_VERIFIER=${VALIDATOR_END_VERIFIER}" ${IMAGE} --timeout=${TIMEOUT} --cacert=/proxy.pem --no-tls=${NOTLS}  >> /var/log/userdata-output || echo "Failed to successfully run the docker container"
       else
-        sudo docker run --env "AWS_REGION=${AWS_REGION}" -e "HTTP_PROXY=${HTTP_PROXY}" -e "START_VERIFIER=${VALIDATOR_START_VERIFIER}" -e "END_VERIFIER=${VALIDATOR_END_VERIFIER}" ${IMAGE} --timeout=${TIMEOUT}  >> /var/log/userdata-output || echo "Failed to successfully run the docker container"
+        podman run --env "AWS_REGION=${AWS_REGION}" -e "HTTP_PROXY=${HTTP_PROXY}" -e "START_VERIFIER=${VALIDATOR_START_VERIFIER}" -e "END_VERIFIER=${VALIDATOR_END_VERIFIER}" ${IMAGE} --timeout=${TIMEOUT}  >> /var/log/userdata-output || echo "Failed to successfully run the docker container"
       fi
       echo "${USERDATA_END}" >> /var/log/userdata-output
 runcmd:
-  - sudo service docker start 2>1 > /dev/null || echo "docker not started by systemctl"
   - /run-container.sh
   - cat /var/log/userdata-output >/dev/console


### PR DESCRIPTION
## What does this PR do? / Related Issues / Jira
[OSD-13342](https://issues.redhat.com//browse/OSD-13342)  Cleanup PR as podman's already preinstalled on the AMIs
```
[   14.741056] cloud-init[1698]: Emulate Docker CLI using podman. Create /etc/containers/nodocker to quiet msg.
```

## Logs 

Validated that the egress command still works:
Happy path:
```
❯ ./osd-network-verifier egress --subnet-id subnet-0ac95f663206a6bcc --region us-east-1
Using region: us-east-1
Created instance with ID: i-0a91d65fa0dd21b7c
EC2 Instance: i-0a91d65fa0dd21b7c Running
Terminating ec2 instance with id i-0a91d65fa0dd21b7c
Summary:
All tests pass!
Success
```
Blocking port 443 egress (forcing it to use the pre-pulled image)
```
❯ ./osd-network-verifier egress --subnet-id subnet-0ac95f663206a6bcc --region us-east-1                                                                 
Using region: us-east-1
Created instance with ID: i-095261e2479e84a2a
EC2 Instance: i-095261e2479e84a2a Running
Terminating ec2 instance with id i-095261e2479e84a2a
Summary:
printing out failures:
 -  egressURL error: Unable to reach api.deadmanssnitch.com:443
 -  egressURL error: Unable to reach openshift.org:443
 -  egressURL error: Unable to reach quay-registry.s3.amazonaws.com:443
 -  egressURL error: Unable to reach sts.amazonaws.com:443
 -  egressURL error: Unable to reach cert-api.access.redhat.com:443
 -  egressURL error: Unable to reach cart-rhcos-ci.s3.amazonaws.com:443
 -  egressURL error: Unable to reach registry.access.redhat.com:443
 -  egressURL error: Unable to reach iam.amazonaws.com:443
 -  egressURL error: Unable to reach http-inputs-osdsecuritylogs.splunkcloud.com:443
 -  egressURL error: Unable to reach sso.redhat.com:80
 -  egressURL error: Unable to reach cm-quay-production-s3.s3.amazonaws.com:443
 -  egressURL error: Unable to reach ec2.amazonaws.com:443
 -  egressURL error: Unable to reach registry.redhat.io:443
 -  egressURL error: Unable to reach route53domains.us-east-1.amazonaws.com:443
 -  egressURL error: Unable to reach console.redhat.com:443
 -  egressURL error: Unable to reach route53.amazonaws.com:443
 -  egressURL error: Unable to reach events.pagerduty.com:443
 -  egressURL error: Unable to reach observatorium.api.openshift.com:443
 -  egressURL error: Unable to reach console.redhat.com:80
 -  egressURL error: Unable to reach quay.io:443
 -  egressURL error: Unable to reach nosnch.in:443
 -  egressURL error: Unable to reach api.openshift.com:443
 -  egressURL error: Unable to reach infogw.api.openshift.com:443
 -  egressURL error: Unable to reach ec2.us-east-1.amazonaws.com:443
 -  egressURL error: Unable to reach sso.redhat.com:443
 -  egressURL error: Unable to reach pull.q1w2.quay.rhcloud.com:443
 -  egressURL error: Unable to reach tagging.us-east-1.amazonaws.com:443
 -  egressURL error: Unable to reach api.access.redhat.com:443
 -  egressURL error: Unable to reach storage.googleapis.com:443
 -  egressURL error: Unable to reach mirror.openshift.com:443
 -  egressURL error: Unable to reach elasticloadbalancing.us-east-1.amazonaws.com:443
 -  egressURL error: Unable to reach events.us-east-1.amazonaws.com:443
Failure!
```