### PR TITLE
Switch to using AWS SDK provided waiters

### DIFF
--- a/docs/aws/aws.md
+++ b/docs/aws/aws.md
@@ -56,7 +56,7 @@ Ensure that the AWS credentials being used have the following permissions. (This
       "Action": [
         "ec2:CreateTags",
         "ec2:RunInstances",
-        "ec2:DescribeInstanceStatus",
+        "ec2:DescribeInstances",
         "ec2:DescribeInstanceTypes",
         "ec2:GetConsoleOutput",
         "ec2:TerminateInstances",

--- a/pkg/clients/aws/aws.go
+++ b/pkg/clients/aws/aws.go
@@ -2,16 +2,11 @@ package aws
 
 import (
 	"context"
-	"errors"
-	"time"
-
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
-	ec2Types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	handledErrors "github.com/openshift/osd-network-verifier/pkg/errors"
-	"github.com/openshift/osd-network-verifier/pkg/helpers"
 )
 
 // Client represents an AWS Client
@@ -59,7 +54,7 @@ func NewClient(ctx context.Context, accessID, accessSecret, sessiontoken, region
 type EC2Client interface {
 	CreateTags(ctx context.Context, params *ec2.CreateTagsInput, optFns ...func(*ec2.Options)) (*ec2.CreateTagsOutput, error)
 	RunInstances(ctx context.Context, params *ec2.RunInstancesInput, optFns ...func(*ec2.Options)) (*ec2.RunInstancesOutput, error)
-	DescribeInstanceStatus(ctx context.Context, input *ec2.DescribeInstanceStatusInput, optFns ...func(*ec2.Options)) (*ec2.DescribeInstanceStatusOutput, error)
+	DescribeInstances(ctx context.Context, params *ec2.DescribeInstancesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeInstancesOutput, error)
 	DescribeInstanceTypes(ctx context.Context, input *ec2.DescribeInstanceTypesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeInstanceTypesOutput, error)
 	GetConsoleOutput(ctx context.Context, input *ec2.GetConsoleOutputInput, optFns ...func(*ec2.Options)) (*ec2.GetConsoleOutputOutput, error)
 	TerminateInstances(ctx context.Context, input *ec2.TerminateInstancesInput, optFns ...func(*ec2.Options)) (*ec2.TerminateInstancesOutput, error)
@@ -74,6 +69,10 @@ func (c *Client) DescribeVpcAttribute(ctx context.Context, input *ec2.DescribeVp
 	return c.ec2Client.DescribeVpcAttribute(ctx, input, optFns...)
 }
 
+func (c *Client) DescribeInstances(ctx context.Context, params *ec2.DescribeInstancesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeInstancesOutput, error) {
+	return c.ec2Client.DescribeInstances(ctx, params, optFns...)
+}
+
 func (c *Client) RunInstances(ctx context.Context, params *ec2.RunInstancesInput, optFns ...func(*ec2.Options)) (*ec2.RunInstancesOutput, error) {
 	return c.ec2Client.RunInstances(ctx, params, optFns...)
 }
@@ -85,63 +84,7 @@ func (c *Client) GetConsoleOutput(ctx context.Context, input *ec2.GetConsoleOutp
 	return c.ec2Client.GetConsoleOutput(ctx, input, optFns...)
 }
 
-// DescribeEC2Instances returns the instance state name of an EC2 instance
-// States and codes
-// 0 : pending
-// 16 : running
-// 32 : shutting-down
-// 48 : terminated
-// 64 : stopping
-// 80 : stopped
-// 401 : failed
-func (c *Client) describeEC2Instances(ctx context.Context, instanceID string) (*ec2Types.InstanceStateName, error) {
-	result, err := c.ec2Client.DescribeInstanceStatus(ctx, &ec2.DescribeInstanceStatusInput{
-		InstanceIds: []string{instanceID},
-	})
-
-	if err != nil {
-		return nil, handledErrors.NewGenericError(err)
-	}
-
-	if len(result.InstanceStatuses) > 1 {
-		// Shouldn't happen, since we're describing using an instance ID
-		return nil, errors.New("more than one EC2 instance found")
-	}
-
-	if len(result.InstanceStatuses) == 0 {
-		// Don't return an error here as if the instance is still too new, it may not be
-		// returned at all.
-		return nil, nil
-	}
-
-	return &result.InstanceStatuses[0].InstanceState.Name, nil
-}
-
-// waitForEC2InstanceCompletion checks every 15s for up to 2 minutes for an instance to be in the running state
-func (c *Client) WaitForEC2InstanceCompletion(ctx context.Context, instanceID string) error {
-	return helpers.PollImmediate(15*time.Second, 2*time.Minute, func() (bool, error) {
-		instanceState, descError := c.describeEC2Instances(ctx, instanceID)
-		if descError != nil {
-			return false, descError
-		}
-
-		if instanceState == nil {
-			// A state is not populated yet, check again later
-			return false, nil
-		}
-
-		switch *instanceState {
-		case ec2Types.InstanceStateNameRunning:
-			// Instance is running, we're done waiting
-			return true, nil
-		default:
-			// Otherwise, check again later
-			return false, nil
-		}
-	})
-}
-
-// terminateEC2Instance terminates target ec2 instance
+// TerminateEC2Instance terminates target ec2 instance
 func (c *Client) TerminateEC2Instance(ctx context.Context, instanceID string) error {
 	input := ec2.TerminateInstancesInput{
 		InstanceIds: []string{instanceID},

--- a/pkg/verifier/aws/entry_point.go
+++ b/pkg/verifier/aws/entry_point.go
@@ -76,15 +76,6 @@ func (a *AwsVerifier) ValidateEgress(vei verifier.ValidateEgressInput) *output.O
 		return a.Output.AddError(err) // fatal
 	}
 
-	if instanceReadyErr := a.AwsClient.WaitForEC2InstanceCompletion(vei.Ctx, instanceID); instanceReadyErr != nil {
-		// try to terminate the created instance
-		err := a.AwsClient.TerminateEC2Instance(vei.Ctx, instanceID)
-		if err != nil {
-			a.Output.AddError(err)
-		}
-		return a.Output.AddError(instanceReadyErr) // fatal
-	}
-
 	if err := a.findUnreachableEndpoints(vei.Ctx, instanceID); err != nil {
 		a.Output.AddError(err)
 	}


### PR DESCRIPTION
This implements [OSD-13305](https://issues.redhat.com//browse/OSD-13305) to switch away from our custom waiters to the AWS SDK provided ones to break apart the changes in #145 

Validated:
* A functional VPC in AWS us-east-2
* The integration test still works in AWS us-east-2