### PR TITLE
Allow default AMI map to be accessable by library consumers

### DIFF
--- a/pkg/verifier/aws/aws_verifier.go
+++ b/pkg/verifier/aws/aws_verifier.go
@@ -61,6 +61,10 @@ type AwsVerifier struct {
 	Output    output.Output
 }
 
+func GetAMIForRegion(region string) string {
+	return defaultAmi[region]
+}
+
 func NewAwsVerifier(accessID, accessSecret, sessionToken, region, profile string, debug bool) (*AwsVerifier, error) {
 	// Create logger
 	builder := ocmlog.NewStdLoggerBuilder()


### PR DESCRIPTION
Creates `GetAMIForRegion` so external code bases can use the AMI IDs. 

Ref: https://issues.redhat.com/browse/OSD-13537

This unblocks https://issues.redhat.com/browse/SDA-6178