### PR TITLE
Self-destructing EC2 instances

### DIFF
--- a/pkg/helpers/config/userdata.yaml
+++ b/pkg/helpers/config/userdata.yaml
@@ -23,3 +23,8 @@ runcmd:
   - sudo service docker start 2>1 > /dev/null || echo "docker not started by systemctl"
   - /run-container.sh
   - cat /var/log/userdata-output >/dev/console
+power_state:
+  delay: 5
+  mode: poweroff
+  message: Auto-terminating instance due to timeout
+  timeout: 300

--- a/pkg/verifier/aws/aws_verifier.go
+++ b/pkg/verifier/aws/aws_verifier.go
@@ -149,6 +149,8 @@ func (a *AwsVerifier) createEC2Instance(input createEC2InstanceInput) (string, e
 		MaxCount:     awsTools.Int32(input.instanceCount),
 		MinCount:     awsTools.Int32(input.instanceCount),
 		InstanceType: ec2Types.InstanceType(input.instanceType),
+		// Tell EC2 to delete this instance if it shuts itself down, in case explicit instance deletion fails
+		InstanceInitiatedShutdownBehavior: ec2Types.ShutdownBehaviorTerminate,
 		// Because we're making this VPC aware, we also have to include a network interface specification
 		NetworkInterfaces: []ec2Types.InstanceNetworkInterfaceSpecification{eniSpecification},
 		// We specify block devices mainly to enable EBS encryption


### PR DESCRIPTION
This PR ensures that no EC2 instances are accidentally left behind by the verifier post-egress-check. To this end, `createEC2Instance()` has been modified to set the [_InstanceInitiatedShutdownBehavior_](https://docs.aws.amazon.com/cdk/api/v1/docs/@aws-cdk_aws-ec2.InstanceInitiatedShutdownBehavior.html) attribute to `TERMINATE` on any verifier-created instances, meaning that EC2 will automatically terminate an instance when it shuts itself down (e.g., by running the `poweroff` shell command). Additionally, a [`power_state`](https://cloudinit.readthedocs.io/en/latest/topics/modules.html#power-state-change) directive has been added to the userdata template instructing cloud-config to power-off the instance either 5 minutes after the validator binary completes or 10 minutes after boot (whichever comes first). Because this auto-shutdown behavior is executed by EC2 and cloud-config, it works even if the verifier client is terminated before it can call `TerminateEC2Instance()` (e.g., because the user pressed Ctrl-C mid-egress-check).

This addresses [OSD-13430](https://issues.redhat.com/browse/OSD-13430), which calls for the verifier to automatically "clean up after itself" such that it doesn't leave potentially-costly AWS resources behind in customer accounts

**Testing this PR**

1. Clone this PR/fork and run `make build` from the root directory. Open the EC2 web console.
3. Execute the verifier as you normally would, e.g., `./osd-network-verifier egress --subnet-id=subnet-0123xyz --profile=default`. Note the instance ID printed.
4. **While the verifier is running**, run `aws ec2 describe-instance-attribute --attribute=instanceInitiatedShutdownBehavior --instance-id=[INSTANCE_ID]` and ensure the "Value" field of the response is set to "terminate."
5. **While the verifier is running**, press Ctrl-C. This prevents the verifier from calling `TerminateEC2Instance()` as it normally would.
6. In the EC2 web console, confirm that the now-orphaned "osd-network-verifier" instance is still running.
7. Wait 10 minutes. While you're waiting, consider opening the serial console (EC2 web console > select running verifier instance > `Connect` > `EC2 serial console`) and confirming that validator output (e.g., `Validating quay.io:443`) is still being printed as usual.
8. After 10 minutes, use the EC2 web console to confirm the verifier instance has been terminated.
