### PR TITLE
fix: pass https proxy if provided even when there's no ca

### DIFF
--- a/pkg/helpers/config/userdata.yaml
+++ b/pkg/helpers/config/userdata.yaml
@@ -16,7 +16,7 @@ write_files:
         echo "${CACERT}" | base64 --decode > /proxy.pem
         sudo docker run -v /proxy.pem:/proxy.pem:Z -e "HTTP_PROXY=${HTTP_PROXY}" -e "HTTPS_PROXY=${HTTPS_PROXY}" --env "AWS_REGION=${AWS_REGION}" -e "START_VERIFIER=${VALIDATOR_START_VERIFIER}" -e "END_VERIFIER=${VALIDATOR_END_VERIFIER}" ${IMAGE} --timeout=${TIMEOUT} --cacert=/proxy.pem --no-tls=${NOTLS}  >> /var/log/userdata-output || echo "Failed to successfully run the docker container"
       else
-        sudo docker run --env "AWS_REGION=${AWS_REGION}" -e "HTTP_PROXY=${HTTP_PROXY}" -e "START_VERIFIER=${VALIDATOR_START_VERIFIER}" -e "END_VERIFIER=${VALIDATOR_END_VERIFIER}" ${IMAGE} --timeout=${TIMEOUT}  >> /var/log/userdata-output || echo "Failed to successfully run the docker container"
+        sudo docker run --env "AWS_REGION=${AWS_REGION}" -e "HTTP_PROXY=${HTTP_PROXY}" -e "HTTPS_PROXY=${HTTPS_PROXY}" -e "START_VERIFIER=${VALIDATOR_START_VERIFIER}" -e "END_VERIFIER=${VALIDATOR_END_VERIFIER}" ${IMAGE} --timeout=${TIMEOUT}  >> /var/log/userdata-output || echo "Failed to successfully run the docker container"
       fi
       echo "${USERDATA_END}" >> /var/log/userdata-output
 runcmd:


### PR DESCRIPTION
Fix: https://issues.redhat.com/browse/OSD-13937

Enables the `https` if the `https proxy` is passed as transparent proxy (when there's no ca)

Testing: it can be tested against the cluster in the ticket
```shell
./osd-network-verifier egress --subnet-id subnet-xx --security-group-id sg-xxx --http-proxy "http://lookup-from-cluster:3128" --https-proxy "http://lookup-from-cluster:3128" --region eu-west-2
```