### PR TITLE
Add additional helper function for setting up AwsVerifier

### DIFF
--- a/pkg/clients/aws/aws.go
+++ b/pkg/clients/aws/aws.go
@@ -23,6 +23,14 @@ func (c *Client) SetClient(e EC2Client) {
 	c.ec2Client = e
 }
 
+// NewClientFromConfig creates an osd-network-verifier AWS Client from an aws-sdk-go-v2 Config
+func NewClientFromConfig(cfg aws.Config) (*Client, error) {
+	return &Client{
+		ec2Client: ec2.NewFromConfig(cfg),
+		Region:    cfg.Region,
+	}, nil
+}
+
 // NewClient creates AWS Client either pass in secret data or profile to work .
 func NewClient(ctx context.Context, accessID, accessSecret, sessiontoken, region, profile string) (*Client, error) {
 	c := &Client{

--- a/pkg/verifier/aws/aws_verifier.go
+++ b/pkg/verifier/aws/aws_verifier.go
@@ -61,8 +61,23 @@ type AwsVerifier struct {
 	Output    output.Output
 }
 
+// GetAMIForRegion returns the default AMI given a region.
+// This is unused within this codebase, but exported so that consumers can access the values of defaultAmi
 func GetAMIForRegion(region string) string {
 	return defaultAmi[region]
+}
+
+// NewAwsVerifierFromConfig assembles an AwsVerifier given an aws-sdk-go-v2 config and an ocm logger
+func NewAwsVerifierFromConfig(cfg awsTools.Config, logger ocmlog.Logger) (*AwsVerifier, error) {
+	awsClient, err := aws.NewClientFromConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return &AwsVerifier{
+		AwsClient: awsClient,
+		Logger:    logger,
+	}, nil
 }
 
 func NewAwsVerifier(accessID, accessSecret, sessionToken, region, profile string, debug bool) (*AwsVerifier, error) {


### PR DESCRIPTION
For [OSD-14143](https://issues.redhat.com//browse/OSD-14143):

Adding a new helper function so consumers can just pass in their own AWS client/logger and not depend on network-verifier's opinionated workflow for assembling them. This will be useful in cases like osdctl and other consumers