### PR TITLE
cleanup: remove unnecessary flag initialization

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/golang/mock v1.6.0
 	github.com/openshift-online/ocm-sdk-go v0.1.224
 	github.com/spf13/cobra v1.4.0
-	github.com/spf13/pflag v1.0.5
 	golang.org/x/oauth2 v0.0.0-20220608161450-d0670ef3b1eb
 	google.golang.org/api v0.84.0
 )

--- a/main.go
+++ b/main.go
@@ -1,21 +1,12 @@
 package main
 
 import (
-	"flag"
 	"os"
 
 	"github.com/openshift/osd-network-verifier/cmd"
-	"github.com/spf13/pflag"
 )
 
 func main() {
-	flags := pflag.NewFlagSet("osd-network-verifier", pflag.ExitOnError)
-
-	if err := flag.CommandLine.Parse([]string{}); err != nil {
-		os.Exit(1)
-	}
-	pflag.CommandLine = flags
-
 	if err := cmd.NewCmdRoot().Execute(); err != nil {
 		os.Exit(1)
 	}


### PR DESCRIPTION
Type: Clean-up

This removes flag initialization that's performed during startup, as it's being checked by cobra already

Testing:
Check the output (against the previous version), you shouldn't be seeing any diff