### PR TITLE
Continue bubbling up the error message for AWS-related errors

### DIFF
--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -32,7 +32,7 @@ func NewGenericError(err error) *GenericError {
 			switch {
 			case ae.ErrorCode() == "UnauthorizedOperation":
 				return &GenericError{
-					message: fmt.Sprintf("missing required permission %s:%s", strings.ToLower(oe.Service()), oe.Operation()),
+					message: fmt.Sprintf("missing required permission %s:%s with error: %s", strings.ToLower(oe.Service()), oe.Operation(), oe.Error()),
 				}
 			default:
 				return &GenericError{

--- a/pkg/verifier/aws/aws_verifier.go
+++ b/pkg/verifier/aws/aws_verifier.go
@@ -205,7 +205,7 @@ func (a *AwsVerifier) createEC2Instance(input createEC2InstanceInput) (string, e
 		if err := a.AwsClient.TerminateEC2Instance(input.ctx, instanceID); err != nil {
 			return instanceID, handledErrors.NewGenericError(err)
 		}
-		return "", fmt.Errorf("terminated %s after timing out waiting for instance to be running", instanceID)
+		return "", fmt.Errorf("%s: terminated %s after timing out waiting for instance to be running", err, instanceID)
 	}
 
 	return instanceID, nil


### PR DESCRIPTION
osd-network-verifier does not display the actual error in some cases, which makes troubleshooting these failure conditions difficult