### PR TITLE
make boilerplate-update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ build:
 	go build $(GOFLAGS) .
 
 .PHONY: fmt
-fmt: 
+fmt:
 	go fmt ./...
 	go mod tidy
 

--- a/boilerplate/openshift/golang-lint/ensure.sh
+++ b/boilerplate/openshift/golang-lint/ensure.sh
@@ -5,9 +5,7 @@ set -eo pipefail
 REPO_ROOT=$(git rev-parse --show-toplevel)
 source $REPO_ROOT/boilerplate/_lib/common.sh
 
-GOLANGCI_LINT_VERSION="1.30.0"
-OPM_VERSION="v1.15.2"
-GRPCURL_VERSION="1.7.0"
+GOLANGCI_LINT_VERSION="1.50.1"
 DEPENDENCY=${1:-}
 GOOS=$(go env GOOS)
 

--- a/boilerplate/openshift/golang-lint/golangci.yml
+++ b/boilerplate/openshift/golang-lint/golangci.yml
@@ -16,13 +16,10 @@ issues:
 linters:
   disable-all: true
   enable:
-  - deadcode
   - errcheck
   - gosimple
   - govet
   - ineffassign
   - staticcheck
-  - structcheck
   - typecheck
   - unused
-  - varcheck


### PR DESCRIPTION
Just a plain `make boilerplate-update` to get this repo up-to-date. This should enable https://github.com/openshift/release/pull/35788 to pass, which will allow getting this repo updated to Go 1.19