### PR TITLE
Allow consuming repos to obtain all URLs associated with egress failures

### DIFF
--- a/integration/main.go
+++ b/integration/main.go
@@ -80,6 +80,10 @@ func onvEgressCheck(region, profile, subnetId string) error {
 	log.Println("Starting ONV egress validation")
 	out := verifier.ValidateEgress(awsVerifier, vei)
 	out.Summary(false)
+	egressFailures := out.GetEgressURLFailures()
+	for _, ef := range egressFailures {
+		log.Printf("egress failure: %s", ef.EgressURL())
+	}
 
 	if out.IsSuccessful() {
 		log.Println("ONV egress validation: Success!")

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -8,12 +8,18 @@ import (
 	"github.com/aws/smithy-go"
 )
 
-// GenericError implements the error interface
 type GenericError struct {
-	message string
+	egressURL string
+	message   string
 }
 
-func (e *GenericError) Error() string { return e.message }
+func (e *GenericError) Error() string {
+	return e.message
+}
+
+func (e *GenericError) EgressURL() string {
+	return e.egressURL
+}
 
 // Ensure GenericError implements the error interface
 var _ error = &GenericError{}
@@ -49,8 +55,9 @@ func NewGenericError(err error) *GenericError {
 }
 
 // NewEgressURLError prepends the provided message with `egressURL error: `
-func NewEgressURLError(message string) error {
+func NewEgressURLError(url string) error {
 	return &GenericError{
-		message: fmt.Sprintf("egressURL error: %s", message),
+		egressURL: url,
+		message:   fmt.Sprintf("egressURL error: %s", url),
 	}
 }

--- a/pkg/errors/errors_test.go
+++ b/pkg/errors/errors_test.go
@@ -1,0 +1,28 @@
+package errors
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestNewEgressURLError(t *testing.T) {
+	tests := []struct {
+		url string
+	}{
+		{
+			url: "www.example.com:443",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.url, func(t *testing.T) {
+			err := NewEgressURLError(test.url)
+			var nve *GenericError
+			if errors.As(err, &nve) {
+				if nve.egressURL != test.url {
+					t.Errorf("expected %v, got %v", test.url, nve.egressURL)
+				}
+			}
+		})
+	}
+}

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -1,6 +1,7 @@
 package output
 
 import (
+	"errors"
 	"fmt"
 
 	handledErrors "github.com/openshift/osd-network-verifier/pkg/errors"
@@ -110,4 +111,21 @@ func (o *Output) Summary(debug bool) {
 // - errors as []error
 func (o *Output) Parse() ([]error, []error, []error) {
 	return o.failures, o.exceptions, o.errors
+}
+
+// GetEgressURLFailures returns only errors related to network egress failures.
+// Use the EgressURL() method to obtain the specific url for each error.
+func (o *Output) GetEgressURLFailures() []*handledErrors.GenericError {
+	egressErrs := []*handledErrors.GenericError{}
+
+	for _, err := range o.failures {
+		var nve *handledErrors.GenericError
+		if errors.As(err, &nve) {
+			if nve.EgressURL() != "" {
+				egressErrs = append(egressErrs, nve)
+			}
+		}
+	}
+
+	return egressErrs
 }

--- a/pkg/output/output_test.go
+++ b/pkg/output/output_test.go
@@ -1,0 +1,52 @@
+package output
+
+import (
+	"errors"
+	"testing"
+
+	nverr "github.com/openshift/osd-network-verifier/pkg/errors"
+)
+
+func TestGetEgressURLFailures(t *testing.T) {
+	tests := []struct {
+		name     string
+		o        *Output
+		expected int
+	}{
+		{
+			name:     "No egress failures",
+			o:        &Output{},
+			expected: 0,
+		},
+		{
+			name: "Only egress failures",
+			o: &Output{
+				failures: []error{
+					nverr.NewEgressURLError("www.example.com:443"),
+					nverr.NewEgressURLError("www.example.com:80"),
+				},
+			},
+			expected: 2,
+		},
+		{
+			name: "Mixture of failures",
+			o: &Output{
+				failures: []error{
+					nverr.NewGenericError(errors.New("oops")),
+					nverr.NewEgressURLError("www.example.com:443"),
+					errors.New("idk"),
+				},
+			},
+			expected: 1,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			failures := test.o.GetEgressURLFailures()
+			if test.expected != len(failures) {
+				t.Errorf("expected %d failures, got %d: %v", test.expected, len(failures), failures)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What does this PR do? / Related Issues / Jira

This PR is a iteration in the vein of [OSD-15078](https://issues.redhat.com//browse/OSD-15078)

Currently, it is difficult for consuming repos to determine exactly
which egress URLs are blocked without manually doing regex parsing on an
array of failure strings that we return. This commit solves this by
adding an egressURL field with EgressURL() and GetEgressURLFailures()
methods so that consuming repos can more easily obtain this information.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added execution results to the PR's readme

## Reviewer's Checklist

- [ ] (This needs to be done after technical review) I've run the branch on my local, verified that the functionality is ok

## How to test this PR locally / Special Instructions

I updated the integration test so that it would print out the egress failures using the new functionality in this PR. Just running it should replicate my results.

## Logs 

The results of me adding this code block to the integration test (which only blocks quay.io:443)
```go
	for _, ef := range egressFailures {
		log.Printf("egress failure: %s", ef.EgressURL())
	}
```

```
❯ ./integration --region us-east-2
2023/03/31 15:16:31 using region us-east-2
2023/03/31 15:16:31 using AZ: us-east-2a
2023/03/31 15:16:31 created VPC: vpc-0cad5fd3990c440db
2023/03/31 15:16:31 enableDnsSupport is true for VPC: vpc-0cad5fd3990c440db
2023/03/31 15:16:31 enableDnsHostnames is true for VPC: vpc-0cad5fd3990c440db
2023/03/31 15:16:31 creating private subnet: 10.0.0.0/25
...a bunch of provisioning
2023/03/31 15:26:15 egress failure: quay.io:443
2023/03/31 15:26:15 ONV egress validation: Failure!
2023/03/31 15:26:15 deleting firewall arn:aws:network-firewall:us-east-2:429297027867:firewall/osd-network-verifier-firewall
...a bunch of deleting
```