### PR TITLE
Move Security Group tag creation to be part of the Security Group creation

### DIFF
--- a/pkg/clients/aws/aws.go
+++ b/pkg/clients/aws/aws.go
@@ -68,7 +68,6 @@ func NewClient(ctx context.Context, accessID, accessSecret, sessiontoken, region
 // Extend EC2Client so that we can mock them all for testing
 // to re-generate mockfile once another interface is added for testing:
 type EC2Client interface {
-	CreateTags(ctx context.Context, params *ec2.CreateTagsInput, optFns ...func(*ec2.Options)) (*ec2.CreateTagsOutput, error)
 	RunInstances(ctx context.Context, params *ec2.RunInstancesInput, optFns ...func(*ec2.Options)) (*ec2.RunInstancesOutput, error)
 	DescribeInstances(ctx context.Context, params *ec2.DescribeInstancesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeInstancesOutput, error)
 	DescribeInstanceTypes(ctx context.Context, input *ec2.DescribeInstanceTypesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeInstanceTypesOutput, error)
@@ -81,10 +80,6 @@ type EC2Client interface {
 	AuthorizeSecurityGroupEgress(ctx context.Context, params *ec2.AuthorizeSecurityGroupEgressInput, optFns ...func(*ec2.Options)) (*ec2.AuthorizeSecurityGroupEgressOutput, error)
 	RevokeSecurityGroupEgress(ctx context.Context, params *ec2.RevokeSecurityGroupEgressInput, optFns ...func(*ec2.Options)) (*ec2.RevokeSecurityGroupEgressOutput, error)
 	DescribeSubnets(ctx context.Context, params *ec2.DescribeSubnetsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeSubnetsOutput, error)
-}
-
-func (c *Client) CreateTags(ctx context.Context, params *ec2.CreateTagsInput, optFns ...func(*ec2.Options)) (*ec2.CreateTagsOutput, error) {
-	return c.ec2Client.CreateTags(ctx, params, optFns...)
 }
 
 func (c *Client) DescribeVpcAttribute(ctx context.Context, input *ec2.DescribeVpcAttributeInput, optFns ...func(*ec2.Options)) (*ec2.DescribeVpcAttributeOutput, error) {


### PR DESCRIPTION
Similar to #169 

This moves the step of creating tags into the same step that creates the Security Group. This is required for the move to tag-based permission enforcement. Without this, the Security Group will not be able to be created since the tags are required at creation time.