### PR TITLE
Refactor to make cleanup idempotent based on tags

### DIFF
--- a/integration/pkg/aws/networkfirewall.go
+++ b/integration/pkg/aws/networkfirewall.go
@@ -18,6 +18,7 @@ import (
 
 type byovpcNetworkFirewallApi interface {
 	CreateRuleGroup(ctx context.Context, params *networkfirewall.CreateRuleGroupInput, optFns ...func(*networkfirewall.Options)) (*networkfirewall.CreateRuleGroupOutput, error)
+	DescribeRuleGroup(ctx context.Context, params *networkfirewall.DescribeRuleGroupInput, optFns ...func(*networkfirewall.Options)) (*networkfirewall.DescribeRuleGroupOutput, error)
 	CreateFirewallPolicy(ctx context.Context, params *networkfirewall.CreateFirewallPolicyInput, optFns ...func(*networkfirewall.Options)) (*networkfirewall.CreateFirewallPolicyOutput, error)
 	DescribeFirewallPolicy(ctx context.Context, params *networkfirewall.DescribeFirewallPolicyInput, optFns ...func(*networkfirewall.Options)) (*networkfirewall.DescribeFirewallPolicyOutput, error)
 	CreateFirewall(ctx context.Context, params *networkfirewall.CreateFirewallInput, optFns ...func(*networkfirewall.Options)) (*networkfirewall.CreateFirewallOutput, error)


### PR DESCRIPTION
## Background

To help with testing for OSD-15914, this PR cleans up resources created by the integration test by tags so that it is idempotent instead of depending on stored ids in state.

Previously, this meant that if the integration test failed or if it was prematurely terminated (e.g. `CTRL+C`'d), it would leave AWS resources behind which is toilsome to cleanup manually. This PR does this by removing the `Name` tag which used to vary based on all resources and filtering resources based on a set of known, default tags to cleanup. The result is an idempotent delete that can be called with `./integration -delete-only` over and over if needed.

## Testing
```
cd integration
go build .
export $(osdctl account cli -i ${ACCT_ID} -p osd-staging-2 -r ${REGION} -oenv | xargs)
./integration -region ${REGION}
CTRL+C any time
./integration -delete-only
./integration -delete-only # To show idempotence
```

## Where it will be useful
This PR will help with testing #176 for the next release by preventing manual cleanup that sometimes occur when interacting with AWS' Firewall API due to lengthy waits.