### PR TITLE
Fix bash error causing osd-network-verifier timeouts pulling from quay.io

### DIFF
--- a/integration/main.go
+++ b/integration/main.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"os"
 	"time"
 
 	ocmlog "github.com/openshift-online/ocm-sdk-go/logging"
@@ -17,11 +18,14 @@ import (
 )
 
 func main() {
-	region := flag.String("region", "us-east-1", "AWS Region")
-	profile := flag.String("profile", "", "AWS Profile")
-	createOnly := flag.Bool("create-only", false, "When specified, only create infrastructure and do not delete")
-	deleteOnly := flag.Bool("delete-only", false, "When specified, delete infrastructure in an idempotent fashion")
-	flag.Parse()
+	f := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	region := f.String("region", "us-east-1", "AWS Region")
+	profile := f.String("profile", "", "AWS Profile")
+	createOnly := f.Bool("create-only", false, "When specified, only create infrastructure and do not delete")
+	deleteOnly := f.Bool("delete-only", false, "When specified, delete infrastructure in an idempotent fashion")
+	if err := f.Parse(os.Args[1:]); err != nil {
+		panic(err)
+	}
 
 	var (
 		cfg aws.Config

--- a/integration/pkg/aws/setup.go
+++ b/integration/pkg/aws/setup.go
@@ -51,6 +51,19 @@ func (id *OnvIntegrationTestData) SetupVpc(ctx context.Context) error {
 		return err
 	}
 
+	log.Printf("waiting up to %s for vpc to become available", 10*time.Second)
+	subnetWaiter := ec2.NewVpcAvailableWaiter(id.ec2Api)
+	if err := subnetWaiter.Wait(ctx, &ec2.DescribeVpcsInput{
+		Filters: []ec2Types.Filter{
+			{
+				Name:   aws.String("vpc-id"),
+				Values: []string{*vpc.Vpc.VpcId},
+			},
+		},
+	}, 10*time.Second); err != nil {
+		return err
+	}
+
 	id.vpcId = vpc.Vpc.VpcId
 	log.Printf("created VPC: %s", *id.vpcId)
 

--- a/pkg/helpers/config/userdata.yaml
+++ b/pkg/helpers/config/userdata.yaml
@@ -8,16 +8,16 @@ write_files:
       echo "${USERDATA_BEGIN}" >> /var/log/userdata-output
       # Look for the image pre-pulled in the AMI, if not available, try to pull it
       IMAGE=`docker images ${VALIDATOR_REPO} -q  | head -n 2 | tail -n 1`
-      if [[ -n "${IMAGE}" ]]; then
-        sudo docker pull ${VALIDATOR_IMAGE} >> /var/log/userdata-output 
+      if [[ -z "${IMAGE}" ]]; then
+        sudo docker pull ${VALIDATOR_IMAGE} >> /var/log/userdata-output
         IMAGE=`docker images ${VALIDATOR_REPO} -q | head -n 2 | tail -n 1`
       fi
       echo "Using IMAGE: $IMAGE" >> /var/log/userdata-output
       if [[ "${CACERT}" != "" ]]; then
         echo "${CACERT}" | base64 --decode > /proxy.pem
-        sudo docker run -v /proxy.pem:/proxy.pem:Z -e "HTTP_PROXY=${HTTP_PROXY}" -e "HTTPS_PROXY=${HTTPS_PROXY}" --env "AWS_REGION=${AWS_REGION}" -e "START_VERIFIER=${VALIDATOR_START_VERIFIER}" -e "END_VERIFIER=${VALIDATOR_END_VERIFIER}" ${IMAGE} --timeout=${TIMEOUT} --config=${CONFIG_PATH} --cacert=/proxy.pem --no-tls=${NOTLS}  >> /var/log/userdata-output || echo "Failed to successfully run the docker container"
+        sudo docker run -v /proxy.pem:/proxy.pem:Z -e "HTTP_PROXY=${HTTP_PROXY}" -e "HTTPS_PROXY=${HTTPS_PROXY}" -e "AWS_REGION=${AWS_REGION}" -e "START_VERIFIER=${VALIDATOR_START_VERIFIER}" -e "END_VERIFIER=${VALIDATOR_END_VERIFIER}" ${IMAGE} --timeout=${TIMEOUT} --config=${CONFIG_PATH} --cacert=/proxy.pem --no-tls=${NOTLS}  >> /var/log/userdata-output || echo "Failed to successfully run the docker container"
       else
-        sudo docker run --env "AWS_REGION=${AWS_REGION}" -e "HTTP_PROXY=${HTTP_PROXY}" -e "HTTPS_PROXY=${HTTPS_PROXY}" -e "START_VERIFIER=${VALIDATOR_START_VERIFIER}" -e "END_VERIFIER=${VALIDATOR_END_VERIFIER}" ${IMAGE} --timeout=${TIMEOUT} --config=${CONFIG_PATH} >> /var/log/userdata-output || echo "Failed to successfully run the docker container"
+        sudo docker run -e "AWS_REGION=${AWS_REGION}" -e "HTTP_PROXY=${HTTP_PROXY}" -e "HTTPS_PROXY=${HTTPS_PROXY}" -e "START_VERIFIER=${VALIDATOR_START_VERIFIER}" -e "END_VERIFIER=${VALIDATOR_END_VERIFIER}" ${IMAGE} --timeout=${TIMEOUT} --config=${CONFIG_PATH} >> /var/log/userdata-output || echo "Failed to successfully run the docker container"
       fi
       echo "${USERDATA_END}" >> /var/log/userdata-output
 runcmd:


### PR DESCRIPTION
## What does this PR do? / Related Issues / Jira

Fixes a bug when osd-network-verifier times out due to being unable to `docker pull`, even when it is not necessary

```bash
      IMAGE=`docker images ${VALIDATOR_REPO} -q  | head -n 2 | tail -n 1`
      if [[ -n "${IMAGE}" ]]; then # should be -z for if $IMAGE is empty
        sudo docker pull ${VALIDATOR_IMAGE} >> /var/log/userdata-output
```

Also some improvements to the integration test, sometimes the test errors because the VPC can take a bit to initialize and cleaned up the help menu.

[OSD-16322](https://issues.redhat.com//browse/OSD-16322)

## Logs 

Original integration test help menu:

```
❯ ./integration -h                            
Usage of ./integration:
  -alsologtostderr
    	log to standard error as well as files
  -create-only
    	When specified, only create infrastructure and do not delete
  -delete-only
    	When specified, delete infrastructure in an idempotent fashion
  -log_backtrace_at value
    	when logging hits line file:N, emit a stack trace
  -log_dir string
    	If non-empty, write log files in this directory
  -log_link string
    	If non-empty, add symbolic links in this directory to the log files
  -logbuflevel int
    	Buffer log messages logged at this level or lower (-1 means don't buffer; 0 means buffer INFO only; ...). Has limited applicability on non-prod platforms.
  -logtostderr
    	log to standard error instead of files
  -profile string
    	AWS Profile
  -region string
    	AWS Region (default "us-east-1")
  -stderrthreshold value
    	logs at or above this threshold go to stderr (default 2)
  -v value
    	log level for V logs
  -vmodule value
    	comma-separated list of pattern=N settings for file-filtered logging

panic calling String method on zero glog.vModuleFlag for flag vmodule: runtime error: invalid memory address or nil pointer dereference
```

New:
```
❯ ./integration -h
Usage of ./integration:
  -create-only
    	When specified, only create infrastructure and do not delete
  -delete-only
    	When specified, delete infrastructure in an idempotent fashion
  -profile string
    	AWS Profile
  -region string
    	AWS Region (default "us-east-1")
```

After fixing this bug, the integration test passes as expected with:
```
❯ ./osd-network-verifier egress --subnet-id subnet-0b0d86c0835e9e905 --security-group-id sg-025aae27d87cbb34d                                                                                                
Using region: us-east-1
Created instance with ID: i-03f10708f4e1efef6
Summary:
printing out failures:
 - egressURL error: quay.io:443

printing out exceptions preventing the verifier from running the specific test:
printing out errors faced during the execution:
Failure!
```