### PR TITLE
Add release step to check the hostedcluster platform type

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -15,7 +15,9 @@ These changes don't automatically mean a change is a breaking or significant cha
 For now, this is mostly manual. It's important to validate that these scenarios are working before making a new release:
 
 * The `networkValidatorImage` in [./pkg/verifier/aws/aws_verifier.go](./pkg/verifier/aws/aws_verifier.go) is the same image that is pre-baked on the `defaultAMI`'s.
-* [./integration](./integration/) has steps to run the egress test against an AWS account to test that the osd-network-verifier is able to run using the pre-baked image on the default AMI.
+* The integration test in [./integration](./integration) is run using the `aws` and `hostedcluster` configurations
+  * `./integration --platform aws`
+  * `./integration --platform hostedcluster`
 * egress test in AWS with a cluster-wide proxy
 * ~~egress test on GCP~~ This should be added back when GCP support is functional again
 

--- a/integration/main.go
+++ b/integration/main.go
@@ -21,6 +21,7 @@ func main() {
 	f := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 	region := f.String("region", "us-east-1", "AWS Region")
 	profile := f.String("profile", "", "AWS Profile")
+	platform := f.String("platform", "aws", "(Optional) Platform type to validate, defaults to `aws`")
 	createOnly := f.Bool("create-only", false, "When specified, only create infrastructure and do not delete")
 	deleteOnly := f.Bool("delete-only", false, "When specified, delete infrastructure in an idempotent fashion")
 	if err := f.Parse(os.Args[1:]); err != nil {
@@ -65,7 +66,7 @@ func main() {
 		return
 	}
 
-	if err := onvEgressCheck(cfg, *data.GetPrivateSubnetId()); err != nil {
+	if err := onvEgressCheck(cfg, *platform, *data.GetPrivateSubnetId()); err != nil {
 		panic(err)
 	}
 
@@ -74,7 +75,7 @@ func main() {
 	}
 }
 
-func onvEgressCheck(cfg aws.Config, subnetId string) error {
+func onvEgressCheck(cfg aws.Config, platform, subnetId string) error {
 	builder := ocmlog.NewStdLoggerBuilder()
 	logger, err := builder.Build()
 	if err != nil {
@@ -92,6 +93,7 @@ func onvEgressCheck(cfg aws.Config, subnetId string) error {
 	vei := verifier.ValidateEgressInput{
 		Timeout:      2 * time.Second,
 		Ctx:          context.TODO(),
+		PlatformType: platform,
 		SubnetID:     subnetId,
 		InstanceType: "t3.micro",
 		Tags:         defaultTags,

--- a/pkg/verifier/aws/entry_point.go
+++ b/pkg/verifier/aws/entry_point.go
@@ -47,6 +47,7 @@ func (a *AwsVerifier) ValidateEgress(vei verifier.ValidateEgressInput) *output.O
 		// Default to AWS
 		configPath = fmt.Sprintf(CONFIG_PATH_FSTRING, helpers.PlatformAWS)
 	}
+	a.Logger.Debug(vei.Ctx, fmt.Sprintf("using config file: %s", configPath))
 
 	var debugPubKey []byte
 	// Check if Import-keypair flag has been passed


### PR DESCRIPTION
Enhancement

## What does this PR do? / Related Issues / Jira

[OSD-16065](https://issues.redhat.com//browse/OSD-16065)

While working on https://github.com/openshift/osdctl/pull/390 I learned that it would have been nice if:

* Part of the release process did a quick sanity check on the required egresses for the `hostedcluster` PlatformType as well, so I updated the integration test to allow passing in a `--platform`.
* There was a debug log to indicate which config file a run was using.

## Logs 

With this logging change and pulling it into osdctl as an example it could look like this:

```
❯ ~/git/openshift/osdctl/osdctl network verify-egress --cluster-id mshen-hyper --subnet-id subnet-05a1fa90715fd0cc3 -S
2023/05/31 21:47:31 getting AWS credentials from backplane-api
2023/05/31 21:47:32 using platform: hostedcluster
2023/05/31 21:47:32 using manually specified subnet-id: [subnet-05a1fa90715fd0cc3]
2023/05/31 21:47:32 searching for security group by tags: [name: tag:Name, values: 242ptvd59ci5mp8onpmc1shcs5s9njbq-default-sg name: tag:kubernetes.io/cluster/242ptvd59ci5mp8onpmc1shcs5s9njbq, values: owned]
2023/05/31 21:47:32 using security-group-id: sg-077a02bbe772f9667
2023/05/31 21:47:32 Preparing to check 1 subnet(s) with network verifier.
2023/05/31 21:47:32 running network verifier for subnet  subnet-05a1fa90715fd0cc3, security group sg-077a02bbe772f9667
2023/05/31 21:47:33 using config file: /app/build/config/hostedcluster.yaml   // <-- NEW LOG LINE HERE
2023/05/31 21:47:34 Created instance with ID: i-03609126c4f3f4d77
Summary:
printing out failures:
 - egressURL error: tagging.us-east-1.amazonaws.com:80
 - egressURL error: servicequotas.us-east-1.amazonaws.com:80
```
