### PR TITLE
OSD-15282 osd-network-verifier with lengthy trust bundles

### DIFF
--- a/pkg/verifier/aws/aws_verifier.go
+++ b/pkg/verifier/aws/aws_verifier.go
@@ -388,7 +388,7 @@ func generateUserData(variables map[string]string) (string, error) {
 	// User data is limited to 16 KB, in raw form, before it is base64-encoded
 	dataBytes := []byte(data)
 	if len(dataBytes) > maxDataSize {
-		return "", fmt.Errorf("UserData size exceeds the maximum limit of 16KB, if you used '--cacert', please check the cacert file size")
+		return "", fmt.Errorf("userData size exceeds the maximum limit of 16KB, if you used '--cacert', please check the cacert file size")
 	}
 
 	return base64.StdEncoding.EncodeToString([]byte(data)), nil

--- a/pkg/verifier/aws/aws_verifier.go
+++ b/pkg/verifier/aws/aws_verifier.go
@@ -377,10 +377,19 @@ func buildTags(tags map[string]string) []ec2Types.Tag {
 }
 
 func generateUserData(variables map[string]string) (string, error) {
+	const maxDataSize = 16 * 1024 // 16KB
+
 	variableMapper := func(varName string) string {
 		return variables[varName]
 	}
 	data := os.Expand(helpers.UserdataTemplate, variableMapper)
+
+	// Convert data to a byte slice and check its length
+	// User data is limited to 16 KB, in raw form, before it is base64-encoded
+	dataBytes := []byte(data)
+	if len(dataBytes) > maxDataSize {
+		return "", fmt.Errorf("UserData size exceeds the maximum limit of 16KB, if you used '--cacert', please check the cacert file size")
+	}
 
 	return base64.StdEncoding.EncodeToString([]byte(data)), nil
 }

--- a/pkg/verifier/aws/aws_verifier_test.go
+++ b/pkg/verifier/aws/aws_verifier_test.go
@@ -2,9 +2,8 @@ package awsverifier
 
 import (
 	"context"
-	"testing"
 	"strings"
-
+	"testing"
 
 	awss "github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -173,17 +172,17 @@ USERDATA END`,
 
 // TestGenerateUserData tests generateUserData function when the user data exceeds the maximum size.
 func TestGenerateUserData_ExceededMaxSize(t *testing.T) {
-    const kiloByte = 1024
-    maxUserDataSize := 16 * kiloByte
-    value := strings.Repeat("a", maxUserDataSize+1)
+	const kiloByte = 1024
+	maxUserDataSize := 16 * kiloByte
+	value := strings.Repeat("a", maxUserDataSize+1)
 
-    maxUserData := map[string]string{
-        "CACERT": value,
-    }
+	maxUserData := map[string]string{
+		"CACERT": value,
+	}
 
-    // generateUserData should return an error if userData exceeds maximum size.
-    _, err := generateUserData(maxUserData)
-    if err == nil {
-        t.Error("generateUserData should return an error if userData exceeds maximum size")
-    }
+	// generateUserData should return an error if userData exceeds maximum size.
+	_, err := generateUserData(maxUserData)
+	if err == nil {
+		t.Error("generateUserData should return an error if userData exceeds maximum size")
+	}
 }

--- a/pkg/verifier/aws/aws_verifier_test.go
+++ b/pkg/verifier/aws/aws_verifier_test.go
@@ -3,6 +3,8 @@ package awsverifier
 import (
 	"context"
 	"testing"
+	"strings"
+
 
 	awss "github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -167,4 +169,21 @@ USERDATA END`,
 			}
 		})
 	}
+}
+
+// TestGenerateUserData tests generateUserData function when the user data exceeds the maximum size.
+func TestGenerateUserData_ExceededMaxSize(t *testing.T) {
+    const kiloByte = 1024
+    maxUserDataSize := 16 * kiloByte
+    value := strings.Repeat("a", maxUserDataSize+1)
+
+    maxUserData := map[string]string{
+        "CACERT": value,
+    }
+
+    // generateUserData should return an error if userData exceeds maximum size.
+    _, err := generateUserData(maxUserData)
+    if err == nil {
+        t.Error("generateUserData should return an error if userData exceeds maximum size")
+    }
 }


### PR DESCRIPTION

- Bug

## What does this PR do? / Related Issues / Jira
We found a case where the size of the trust bundle caused the length of user-data to exceed its maximum of 16384 bytes, this PR is to return a clear and specific error in case of unsupported length so that we can ensure not block install wrongfully and fail fast. 

Jira: [OSD-15282](https://issues.redhat.com/browse/OSD-15282)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have tested the functionality against  aws, it doesn't cause any regression
- [x] I have added execution results to the PR's readme


## Logs 

```
## without --cacert flag

$ ./osd-network-verifier egress --platform aws --subnet-id subnet-0a3e18468e9495462 --security-group-id sg-0e0bec2444c1282f9 --profile default --region us-east-1                                                                                                       1 ↵
Using region: us-east-1
Created instance with ID: i-05979e1b00a73face
Summary:
printing out failures:
... omitted ...

```

```
$ ./osd-network-verifier egress --platform aws --subnet-id subnet-0a3e18468e9495462 --security-group-id sg-0e0bec2444c1282f9 --profile default --region us-east-1 --cacert tls-ca-bundle.pem
Using region: us-east-1
Summary:
printing out failures:
printing out exceptions preventing the verifier from running the specific test:
printing out errors faced during the execution:
 - network verifier error: UserData size exceeds the maximum limit of 16KB, if you used '--cacert', please check the cacert file size

$ ls -lh tls-ca-bundle.pem
-rw-r--r--  1 jude  staff   214K Jun 21 15:48 tls-ca-bundle.pem
```
> tls-ca-bundle.pem is from fedora 38 Server path `/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem` 
