### PR TITLE
Add terraform IaC for osd-network-verifier example/quick testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,46 @@ coverage.out
 
 # Certs
 *.pem
+
+# Local .terraform directories
+**/.terraform/*
+
+# Lock file
+.terraform.lock.hcl
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data, such as
+# password, private keys, and other secrets. These should not be part of version 
+# control as they are data points which are potentially sensitive and subject 
+# to change depending on the environment.
+*.tfvars
+*.tfvars.json
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc
+
+# MacOS General
+.DS_Store
+.AppleDouble
+.LSOverride

--- a/README.md
+++ b/README.md
@@ -25,6 +25,22 @@ The recommended workflow of diagnostic use of ONV is shown in the following flow
 ### Building
 `make build`: Builds `osd-network-verifier` executable in base directory
 
+## Terraform Scripts (AWS)
+
+The Terraform scripts in this repository allow you to set up a secure and scalable network infrastructure in AWS for testing. It will create a VPC with public, private, and firewall(optinal) subnets, an Internet Gateway, a NAT Gateway, and a network firewall(optinal).
+
+### Getting Started
+
+1. Clone this repository.
+2. Navigate to the Terraform scripts directory: `examples/aws/terraform`.
+3. Copy the `terraform.tfvars.example` file to `terraform.tfvars` and replace the placeholder values with your actual values.
+4. Run `terraform init` to initialize Terraform.
+5. Run `terraform apply` to create the infrastructure.
+
+See the Terraform `README.md` for detailed instructions.
+- [VPC with no Firewall](examples/aws/terraform/vpc/README.md)
+- [VPC with Firewall](examples/aws/terraform/vpc-firewall/README.md)
+
 ## Contributing and Maintenance
 If interested, please fork this repo and create pull requests to the `main` branch.
 

--- a/examples/aws/terraform/vpc-firewall/README.md
+++ b/examples/aws/terraform/vpc-firewall/README.md
@@ -1,0 +1,114 @@
+# AWS VPC with firewall by Terraform for OSD Network Verifier Test
+
+This repository contains Terraform scripts to set up a VPC in AWS with public, private, and firewall subnets. An Internet Gateway is also set up for the VPC. A network firewall with a firewall policy and a rule group is also set up for the VPC.
+
+Use `block_domains` to add the domain you want to blocked and then test with osd-network-verifier.
+
+## Prerequisites
+
+- Terraform 0.12.x or later
+- AWS Account
+
+## Usage
+
+### AWS Credentials
+
+This script uses AWS profiles for authentication. You should configure your AWS credentials in your AWS credentials file. The default location is `~/.aws/credentials` on Unix systems and `C:\Users\USERNAME\.aws\credentials` on Windows. You can specify the profile to use in the `terraform.tfvars` file.
+
+### Configuration
+
+Before running the scripts, you need to configure the variables used by the scripts. A `terraform.tfvars.example` file is provided as a template. Here are the steps to configure the variables:
+
+1. Copy the example file:
+
+    ```bash
+    cp terraform.tfvars.example terraform.tfvars
+    ```
+
+2. Open the terraform.tfvars file in a text editor.
+
+3. Replace the Variable values with your actual values. Here is an explanation of each variable:
+
+- `profile`: The AWS profile to use. This profile should be configured in your AWS credentials file.
+- `region`: The AWS region where resources will be created.
+- `availability_zone`: The availability zone within the region where subnets will be created.
+- `vpc_cidr_block`: The CIDR block for the VPC.
+- `public_subnet_cidr_block`: The CIDR block for the public subnet within the VPC.
+- `private_subnet_cidr_block`: The CIDR block for the private subnet within the VPC.
+- `firewall_subnet_cidr_block`: The CIDR block for the firewall subnet within the VPC.
+- `block_domains`: A list of domains that you want to block.
+- `firewall_name`: The name of the network firewall.
+- `firewall_policy_name`: The name of the firewall policy.
+- `rule_group_name`: The name of the stateful rule group for the firewall.
+
+### Running the scripts
+
+1. Initialize Terraform:
+
+```bash
+terraform init
+```
+
+
+2. Check the execution plan:
+
+```bash
+terraform plan
+```
+
+
+3. Apply the changes:
+
+```bash
+terraform apply
+```
+
+
+4. To destroy the resources:
+
+```bash
+terraform destroy
+```
+
+
+## Outputs
+
+The scripts output the IDs of the created VPC and subnets.
+
+- `vpc_id`: The ID of the VPC.
+- `region`: The region of the VPC.
+- `public_subnet_id`: The ID of the public subnet.
+- `private_subnet_id`: The ID of the private subnet.
+- `firewall_subnet_id`: The ID of the firewall subnet.
+
+## Test OSD Network Verifier
+
+Use the following command example tp verfifer the block domain failed the verifier.
+
+```bash
+osd-network-verifier egress \
+    --platform aws \
+    --subnet-id $private_subnet_id \
+    --security-group-id "" \
+    --profile $aws_profile \
+    --region $region
+```
+Replace `$private_subnet_id`, `$aws_profile` and `$region` with the terraform output value.
+
+Example:
+
+```bash
+$ ./osd-network-verifier egress --platform aws --subnet-id subnet-080exxxxxxxx6aef1 --security-group-id "" --profile default --region us-east-1                                                                                                                         1 ↵
+Using region: us-east-1
+Created security group with ID: sg-04f4xxxxxxxx53f29
+Created instance with ID: i-0197xxxxxxxx8c4ce
+Summary:
+printing out failures:
+ - egressURL error: api.openshift.com:443
+ - egressURL error: quay.io:443
+ - egressURL error: registry.redhat.io:443
+
+printing out exceptions preventing the verifier from running the specific test:
+printing out errors faced during the execution:
+Failure!
+```

--- a/examples/aws/terraform/vpc-firewall/main.tf
+++ b/examples/aws/terraform/vpc-firewall/main.tf
@@ -1,0 +1,200 @@
+# AWS provider configuration
+provider "aws" {
+  profile = var.profile # AWS profile
+  region  = var.region  # AWS region
+}
+
+# Create a VPC
+resource "aws_vpc" "main" {
+  cidr_block           = var.vpc_cidr_block
+  enable_dns_hostnames = true
+}
+
+# Create an Internet Gateway and attach it to the VPC
+resource "aws_internet_gateway" "igw" {
+  vpc_id = aws_vpc.main.id # ID of the VPC
+}
+
+# Create a public subnet within the VPC
+resource "aws_subnet" "public" {
+  vpc_id            = aws_vpc.main.id              # ID of the VPC
+  cidr_block        = var.public_subnet_cidr_block # CIDR block for public subnet
+  availability_zone = var.availability_zone        # Availability Zone
+}
+
+# Create a private subnet within the VPC
+resource "aws_subnet" "private" {
+  vpc_id            = aws_vpc.main.id               # ID of the VPC
+  cidr_block        = var.private_subnet_cidr_block # CIDR block for private subnet
+  availability_zone = var.availability_zone         # Availability Zone
+}
+
+# Create a firewall subnet within the VPC
+resource "aws_subnet" "firewall" {
+  vpc_id            = aws_vpc.main.id                # ID of the VPC
+  cidr_block        = var.firewall_subnet_cidr_block # CIDR block for firewall subnet
+  availability_zone = var.availability_zone          # Availability Zone
+}
+
+# Create a route table for the public subnet
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id # ID of the VPC
+}
+
+# Create a route table for the private subnet
+resource "aws_route_table" "private" {
+  vpc_id = aws_vpc.main.id # ID of the VPC
+}
+
+# Create a route table for the firewall subnet
+resource "aws_route_table" "firewall" {
+  vpc_id = aws_vpc.main.id # ID of the VPC
+}
+
+# Allocate an Elastic IP address for the NAT Gateway
+resource "aws_eip" "nat" {
+  domain = "vpc"
+}
+
+# Create a NAT Gateway and assign it the allocated Elastic IP address
+resource "aws_nat_gateway" "nat" {
+  subnet_id     = aws_subnet.public.id      # ID of pubic subnet
+  allocation_id = aws_eip.nat.allocation_id # ID of the EIP address
+}
+
+# Associate the public subnet with its route table
+resource "aws_route_table_association" "public" {
+  subnet_id      = aws_subnet.public.id      # ID of public subnet
+  route_table_id = aws_route_table.public.id # ID of public route table
+}
+
+# Associate the private subnet with its route table
+resource "aws_route_table_association" "private" {
+  subnet_id      = aws_subnet.private.id      # ID of private subnet
+  route_table_id = aws_route_table.private.id # ID of private route table
+}
+
+# Associate the firewall subnet with its route table
+resource "aws_route_table_association" "firewall" {
+  subnet_id      = aws_subnet.firewall.id      # ID of firewall subnet
+  route_table_id = aws_route_table.firewall.id # ID of firewall route table
+}
+
+# Create a network firewall
+resource "aws_networkfirewall_firewall" "firewall" {
+  name                = var.firewall_name                                       # Name of the firewall
+  firewall_policy_arn = aws_networkfirewall_firewall_policy.firewall_policy.arn # ARN of the firewall policy
+  vpc_id              = aws_vpc.main.id                                         # ID of the VPC
+
+  # Map the firewall to the firewall subnet
+  subnet_mapping {
+    subnet_id = aws_subnet.firewall.id # ID of firewall subnet
+  }
+}
+
+# Create a firewall policy
+resource "aws_networkfirewall_firewall_policy" "firewall_policy" {
+  name = var.firewall_policy_name # Name of the firewall policy
+
+  # Define the firewall policy
+  firewall_policy {
+    stateless_default_actions          = ["aws:forward_to_sfe"]
+    stateless_fragment_default_actions = ["aws:forward_to_sfe"]
+    stateful_rule_group_reference {
+      resource_arn = aws_networkfirewall_rule_group.stateful_rule_group.arn # ARN of the rule group
+    }
+  }
+}
+
+# Create a stateful rule group for the firewall
+resource "aws_networkfirewall_rule_group" "stateful_rule_group" {
+  capacity = 100                 # Capacity of the rule group
+  name     = var.rule_group_name # Name of the rule group
+
+  # Define the rule group
+  rule_group {
+    rules_source {
+      rules_source_list {
+        generated_rules_type = "DENYLIST"
+        target_types         = ["TLS_SNI"]
+        targets              = var.block_domains # List of domains to block
+      }
+    }
+  }
+
+  type = "STATEFUL" # Type of the rule group
+}
+
+# Define a route for the public subnet
+resource "aws_route" "route_public" {
+  route_table_id         = aws_route_table.public.id # ID of public route table
+  destination_cidr_block = "0.0.0.0/0"               # CIDR block for the destination
+  # ID of firewall VPC endpoint 
+  # aws_networkfirewall_firewall.firewall.firewall_status[0].sync_states[*].attachment[0].endpoint_id is a set of object                                                                                            
+  vpc_endpoint_id = (aws_networkfirewall_firewall.firewall.firewall_status[0].sync_states[*].attachment[0].endpoint_id)[0]
+}
+
+# Define a route for the private subnet
+resource "aws_route" "route_private" {
+  route_table_id         = aws_route_table.private.id # ID of private route table
+  destination_cidr_block = "0.0.0.0/0"                # CIDR block for the destination
+  nat_gateway_id         = aws_nat_gateway.nat.id     # ID of the NAT Gateway
+}
+
+# Define a route for the firewall subnet
+resource "aws_route" "route_firewall" {
+  route_table_id         = aws_route_table.firewall.id # ID of firewall route table
+  destination_cidr_block = "0.0.0.0/0"                 # CIDR block for the destination
+  gateway_id             = aws_internet_gateway.igw.id # ID of the Internet Gateway
+}
+
+# Create a route table for the Internet Gateway
+resource "aws_route_table" "igw" {
+  vpc_id = aws_vpc.main.id # ID of the VPC
+}
+
+# Define a route for the Internet Gateway
+resource "aws_route" "route_igw" {
+  route_table_id         = aws_route_table.igw.id       # ID of Internet Gateway route table
+  destination_cidr_block = var.public_subnet_cidr_block # CIDR block for public subnet
+  # ID of firewall VPC endpoint 
+  # aws_networkfirewall_firewall.firewall.firewall_status[0].sync_states[*].attachment[0].endpoint_id is a set of object 
+  vpc_endpoint_id = (aws_networkfirewall_firewall.firewall.firewall_status[0].sync_states[*].attachment[0].endpoint_id)[0]
+}
+# Edge Associate the Internet Gateway with route table 
+resource "aws_route_table_association" "igw_association" {
+  gateway_id     = aws_internet_gateway.igw.id # ID of the Internet Gateway
+  route_table_id = aws_route_table.igw.id      # ID of Internet Gateway route table
+}
+
+# Output the ID of the VPC
+output "vpc_id" {
+  description = "The ID of the VPC"
+  value       = aws_vpc.main.id
+}
+
+# Output the region of the VPC
+data "aws_region" "current" {}
+
+output "region" {
+  description = "The region of the VPC"
+  value       = data.aws_region.current.name
+}
+
+# Output the ID of the public subnet
+output "public_subnet_id" {
+  description = "The ID of the Public Subnet"
+  value       = aws_subnet.public.id
+}
+
+# Output the ID of the private subnet
+output "private_subnet_id" {
+  description = "The ID of the Private Subnet"
+  value       = aws_subnet.private.id
+}
+
+# Output the ID of the firewall subnet
+output "firewall_subnet_id" {
+  description = "The ID of the Private Subnet"
+  value       = aws_subnet.firewall.id
+}

--- a/examples/aws/terraform/vpc-firewall/terraform.tfvars.example
+++ b/examples/aws/terraform/vpc-firewall/terraform.tfvars.example
@@ -1,0 +1,40 @@
+# Your AWS Profile
+# Replace "default" with the name of the profile you want to use
+# This profile should be configured in your AWS credentials file, typically located at ~/.aws/credentials on Unix-based systems and C:\Users\USERNAME\.aws\credentials on Windows. 
+# The profile configuration should look something like this:
+# 
+# [default]
+# aws_access_key_id = YOUR_ACCESS_KEY
+# aws_secret_access_key = YOUR_SECRET_KEY
+#
+profile = "default"
+
+# The AWS region where you want to create your resources
+region = "us-east-1"
+
+# The availability zone within the region where you want to create your subnets
+availability_zone = "us-east-1a"
+
+# The CIDR block for your VPC
+vpc_cidr_block = "10.0.0.0/16"
+
+# The CIDR block for your public subnet within your VPC
+public_subnet_cidr_block = "10.0.0.0/24"
+
+# The CIDR block for your private subnet within your VPC
+private_subnet_cidr_block = "10.0.1.0/24"
+
+# The CIDR block for your firewall subnet within your VPC
+firewall_subnet_cidr_block = "10.0.2.0/24"
+
+# A list of domains that you want to block
+block_domains = [".quay.io", "api.openshift.com", ".redhat.io"]
+
+# Name of the network firewall
+firewall_name = "myFirewall"
+
+# Name of the firewall policy
+firewall_policy_name = "myPolicy"
+
+# Name of the stateful rule group for the firewall
+rule_group_name = "myRuleGroup"

--- a/examples/aws/terraform/vpc-firewall/variables.tf
+++ b/examples/aws/terraform/vpc-firewall/variables.tf
@@ -1,0 +1,76 @@
+# AWS Profile to use
+variable "profile" {
+  description = "AWS Profile to use"
+  type        = string
+  default     = "default"
+}
+
+# The AWS Region where resources will be created
+variable "region" {
+  description = "AWS Region"
+  type        = string      # Expect a string input
+  default     = "us-east-1" # Default to US East (N. Virginia)
+}
+
+# The availability zone where the subnets will be created
+variable "availability_zone" {
+  description = "The availability zone where the subnets will be created"
+  type        = string       # Expect a string input
+  default     = "us-east-1a" # Default to US East (N. Virginia) AZ a
+}
+
+# CIDR block for the VPC
+variable "vpc_cidr_block" {
+  description = "CIDR block for the VPC"
+  type        = string        # Expect a string input
+  default     = "10.0.0.0/16" # Default to a /16 block within the 10.0.0.0 private network
+}
+
+# CIDR block for the public subnet
+variable "public_subnet_cidr_block" {
+  description = "CIDR block for the public subnet"
+  type        = string        # Expect a string input
+  default     = "10.0.0.0/24" # Default to a /24 block within the 10.0.0.0 private network
+}
+
+# CIDR block for the private subnet
+variable "private_subnet_cidr_block" {
+  description = "CIDR block for the private subnet"
+  type        = string        # Expect a string input
+  default     = "10.0.1.0/24" # Default to a /24 block within the 10.0.0.0 private network
+}
+
+# CIDR block for the firewall subnet
+variable "firewall_subnet_cidr_block" {
+  description = "CIDR block for the firewall subnet"
+  type        = string        # Expect a string input
+  default     = "10.0.2.0/24" # Default to a /24 block within the 10.0.0.0 private network
+}
+
+# Name of the network firewall
+variable "firewall_name" {
+  description = "Name of the network firewall"
+  type        = string
+  default     = "myFirewall"
+}
+
+# Name of the firewall policy
+variable "firewall_policy_name" {
+  description = "Name of the firewall policy"
+  type        = string
+  default     = "myPolicy"
+}
+
+# Name of the stateful rule group for the firewall
+variable "rule_group_name" {
+  description = "Name of the stateful rule group for the firewall"
+  type        = string
+  default     = "myRuleGroup"
+}
+
+# List of domains to block
+variable "block_domains" {
+  description = "List of domains to block"
+  type        = list(string)                                    # Expect a list of strings input
+  default     = [".quay.io", "api.openshift.com", ".redhat.io"] # Default to these domains
+}

--- a/examples/aws/terraform/vpc/README.md
+++ b/examples/aws/terraform/vpc/README.md
@@ -1,0 +1,101 @@
+# AWS VPC with no firewall by Terraform for OSD Network Verifier Test
+
+This repository contains Terraform scripts to set up a VPC in AWS with public, private subnets, and aslo an Internet Gateway. 
+
+## Prerequisites
+
+- Terraform 0.12.x or later
+- AWS Account
+
+## Usage
+
+### AWS Credentials
+
+This script uses AWS profiles for authentication. You should configure your AWS credentials in your AWS credentials file. The default location is `~/.aws/credentials` on Unix systems and `C:\Users\USERNAME\.aws\credentials` on Windows. You can specify the profile to use in the `terraform.tfvars` file.
+
+### Configuration
+
+Before running the scripts, you need to configure the variables used by the scripts. A `terraform.tfvars.example` file is provided as a template. Here are the steps to configure the variables:
+
+1. Copy the example file:
+
+    ```bash
+    cp terraform.tfvars.example terraform.tfvars
+    ```
+
+2. Open the terraform.tfvars file in a text editor.
+
+3. Replace the Variable values with your actual values. Here is an explanation of each variable:
+
+- `profile`: The AWS profile to use. This profile should be configured in your AWS credentials file.
+- `region`: The AWS region where resources will be created.
+- `availability_zone`: The availability zone within the region where subnets will be created.
+- `vpc_cidr_block`: The CIDR block for the VPC.
+- `public_subnet_cidr_block`: The CIDR block for the public subnet within the VPC.
+- `private_subnet_cidr_block`: The CIDR block for the private subnet within the VPC.
+
+### Running the scripts
+
+1. Initialize Terraform:
+
+```bash
+terraform init
+```
+
+
+2. Check the execution plan:
+
+```bash
+terraform plan
+```
+
+
+3. Apply the changes:
+
+```bash
+terraform apply
+```
+
+
+4. To destroy the resources:
+
+```bash
+terraform destroy
+```
+
+
+## Outputs
+
+The scripts output the IDs of the created VPC and subnets.
+
+- `vpc_id`: The ID of the VPC.
+- `region`: The region of the VPC.
+- `public_subnet_id`: The ID of the public subnet.
+- `private_subnet_id`: The ID of the private subnet.
+
+
+## Test OSD Network Verifier
+
+Use the following command example tp verfifer the block domain failed the verifier.
+
+```bash
+osd-network-verifier egress \
+    --platform aws \
+    --subnet-id $private_subnet_id \
+    --security-group-id "" \
+    --profile $aws_profile \
+    --region $region
+```
+Replace `$private_subnet_id`, `$aws_profile` and `$region` with the terraform output value.
+
+Example:
+
+```bash
+$ ./osd-network-verifier egress --platform aws --subnet-id subnet-0654xxxxxxxxfd95b --security-group-id "" --profile default --region us-east-1                                                                                              1 ↵
+Using region: us-east-1
+Created security group with ID: sg-069exxxxxxxx200ee
+Created instance with ID: i-08e1xxxxxxxx768d9
+Summary:
+All tests passed!
+Success
+```

--- a/examples/aws/terraform/vpc/main.tf
+++ b/examples/aws/terraform/vpc/main.tf
@@ -1,0 +1,100 @@
+# AWS provider configuration
+provider "aws" {
+  profile = var.profile # AWS profile
+  region  = var.region  # AWS region
+}
+
+# Create a VPC
+resource "aws_vpc" "main" {
+  cidr_block           = var.vpc_cidr_block
+  enable_dns_hostnames = true
+}
+
+# Create an Internet Gateway and attach it to the VPC
+resource "aws_internet_gateway" "igw" {
+  vpc_id = aws_vpc.main.id # ID of the VPC
+}
+
+# Create a public subnet within the VPC
+resource "aws_subnet" "public" {
+  vpc_id                  = aws_vpc.main.id              # ID of the VPC
+  cidr_block              = var.public_subnet_cidr_block # CIDR block for public subnet
+  availability_zone       = var.availability_zone        # Availability Zone
+  map_public_ip_on_launch = true
+}
+
+# Create a private subnet within the VPC
+resource "aws_subnet" "private" {
+  vpc_id            = aws_vpc.main.id               # ID of the VPC
+  cidr_block        = var.private_subnet_cidr_block # CIDR block for private subnet
+  availability_zone = var.availability_zone         # Availability Zone
+}
+
+# Create a route table for the public subnet
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id # ID of the VPC
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.igw.id
+  }
+}
+
+# Create a route table for the private subnet
+resource "aws_route_table" "private" {
+  vpc_id = aws_vpc.main.id # ID of the VPC
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = aws_nat_gateway.nat.id
+  }
+}
+
+# Allocate an Elastic IP address for the NAT Gateway
+resource "aws_eip" "nat" {
+  domain = "vpc"
+}
+
+# Create a NAT Gateway and assign it the allocated Elastic IP address
+resource "aws_nat_gateway" "nat" {
+  subnet_id     = aws_subnet.public.id      # ID of pubic subnet
+  allocation_id = aws_eip.nat.allocation_id # ID of the EIP address
+}
+
+# Associate the public subnet with its route table
+resource "aws_route_table_association" "public" {
+  subnet_id      = aws_subnet.public.id      # ID of public subnet
+  route_table_id = aws_route_table.public.id # ID of public route table
+}
+
+# Associate the private subnet with its route table
+resource "aws_route_table_association" "private" {
+  subnet_id      = aws_subnet.private.id      # ID of private subnet
+  route_table_id = aws_route_table.private.id # ID of private route table
+}
+
+# Output the ID of the VPC
+output "vpc_id" {
+  description = "The ID of the VPC"
+  value       = aws_vpc.main.id
+}
+
+# Output the region of the VPC
+data "aws_region" "current" {}
+
+output "region" {
+  description = "The region of the VPC"
+  value       = data.aws_region.current.name
+}
+
+# Output the ID of the public subnet
+output "public_subnet_id" {
+  description = "The ID of the Public Subnet"
+  value       = aws_subnet.public.id
+}
+
+# Output the ID of the private subnet
+output "private_subnet_id" {
+  description = "The ID of the Private Subnet"
+  value       = aws_subnet.private.id
+}
+

--- a/examples/aws/terraform/vpc/terraform.tfvars.example
+++ b/examples/aws/terraform/vpc/terraform.tfvars.example
@@ -1,0 +1,25 @@
+# Your AWS Profile
+# Replace "default" with the name of the profile you want to use
+# This profile should be configured in your AWS credentials file, typically located at ~/.aws/credentials on Unix-based systems and C:\Users\USERNAME\.aws\credentials on Windows. 
+# The profile configuration should look something like this:
+# 
+# [default]
+# aws_access_key_id = YOUR_ACCESS_KEY
+# aws_secret_access_key = YOUR_SECRET_KEY
+#
+profile = "default"
+
+# The AWS region where you want to create your resources
+region = "us-east-1"
+
+# The availability zone within the region where you want to create your subnets
+availability_zone = "us-east-1a"
+
+# The CIDR block for your VPC
+vpc_cidr_block = "10.0.0.0/16"
+
+# The CIDR block for your public subnet within your VPC
+public_subnet_cidr_block = "10.0.0.0/24"
+
+# The CIDR block for your private subnet within your VPC
+private_subnet_cidr_block = "10.0.1.0/24"

--- a/examples/aws/terraform/vpc/variables.tf
+++ b/examples/aws/terraform/vpc/variables.tf
@@ -1,0 +1,41 @@
+# AWS Profile to use
+variable "profile" {
+  description = "AWS Profile to use"
+  type        = string
+  default     = "default"
+}
+
+# The AWS Region where resources will be created
+variable "region" {
+  description = "AWS Region"
+  type        = string      # Expect a string input
+  default     = "us-east-1" # Default to US East (N. Virginia)
+}
+
+# The availability zone where the subnets will be created
+variable "availability_zone" {
+  description = "The availability zone where the subnets will be created"
+  type        = string       # Expect a string input
+  default     = "us-east-1a" # Default to US East (N. Virginia) AZ a
+}
+
+# CIDR block for the VPC
+variable "vpc_cidr_block" {
+  description = "CIDR block for the VPC"
+  type        = string        # Expect a string input
+  default     = "10.0.0.0/16" # Default to a /16 block within the 10.0.0.0 private network
+}
+
+# CIDR block for the public subnet
+variable "public_subnet_cidr_block" {
+  description = "CIDR block for the public subnet"
+  type        = string        # Expect a string input
+  default     = "10.0.0.0/24" # Default to a /24 block within the 10.0.0.0 private network
+}
+
+# CIDR block for the private subnet
+variable "private_subnet_cidr_block" {
+  description = "CIDR block for the private subnet"
+  type        = string        # Expect a string input
+  default     = "10.0.1.0/24" # Default to a /24 block within the 10.0.0.0 private network
+}


### PR DESCRIPTION

- Enhancement/Feature

## What does this PR do? / Related Issues / Jira
Use Terraform IaC to provide an alternative way to quick establish a VPC with or without a firewall for osd-network-verifier testing.

This Terraform script sets up a network infrastructure in the AWS Cloud. The infrastructure includes a Virtual Private Cloud (VPC), subnets, a network firewall(optional), and an Internet Gateway.

1. **VPC:** The script creates a VPC in the specified AWS region. 

2. **Subnets:** Three subnets are created within the VPC - a public subnet, a private subnet, and a firewall subnet. Each subnet is created in the specified availability zone with its respective CIDR block.

3. **Internet Gateway:** An Internet Gateway is created and attached to the VPC. This allows the VPC to communicate with the Internet.

4. **Network Firewall(optional):** A network firewall is set up for the VPC. The firewall is associated with the firewall subnet. The firewall has a policy and a rule group. The policy defines the stateless actions to take for packets. The rule group contains a list of domains to block.

5. **NAT Gateway:** A NAT Gateway is created in the public subnet. This allows instances in the private subnet to connect to the internet or other AWS services.

6. **Routing:** Route tables and associations are created for the subnets. The public and firewall subnets are associated with the Internet Gateway, allowing them to communicate directly with the Internet. The private subnet is associated with the NAT Gateway, allowing it to access the Internet via the NAT Gateway.

The script outputs the IDs of the created VPC and subnets. 

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have tested the functionality against aws, it doesn't cause any regression
- [x] I have added execution results to the PR's readme

