### PR TITLE
Add rules allowing proxy traffic to auto-generated security group

### DIFF
--- a/cmd/egress/cmd.go
+++ b/cmd/egress/cmd.go
@@ -220,7 +220,7 @@ are set correctly before execution.
 	validateEgressCmd.Flags().StringVar(&config.vpcSubnetID, "subnet-id", "", "source subnet ID")
 	validateEgressCmd.Flags().StringVar(&config.cloudImageID, "image-id", "", "(optional) cloud image for the compute instance")
 	validateEgressCmd.Flags().StringVar(&config.instanceType, "instance-type", "", "(optional) compute instance type")
-	validateEgressCmd.Flags().StringVar(&config.securityGroupId, "security-group-id", "", "security group ID to attach to the created EC2 instance")
+	validateEgressCmd.Flags().StringVar(&config.securityGroupId, "security-group-id", "", "(optional) sec. group to attach to the created EC2 instance. If absent, one will be created")
 	validateEgressCmd.Flags().StringVar(&config.region, "region", "", fmt.Sprintf("(optional) compute instance region. If absent, environment var %[1]v = %[2]v and %[3]v = %[4]v will be used", awsRegionEnvVarStr, awsRegionDefault, gcpRegionEnvVarStr, gcpRegionDefault))
 	validateEgressCmd.Flags().StringToStringVar(&config.cloudTags, "cloud-tags", map[string]string{}, "(optional) comma-seperated list of tags to assign to cloud resources e.g. --cloud-tags key1=value1,key2=value2")
 	validateEgressCmd.Flags().BoolVar(&config.debug, "debug", false, "(optional) if true, enable additional debug-level logging")
@@ -237,10 +237,6 @@ are set correctly before execution.
 	validateEgressCmd.Flags().StringVar(&config.importKeyPair, "import-keypair", "", "(optional) Takes the path to your public key used to connect to Debug Instance. Automatically skips Termination")
 
 	if err := validateEgressCmd.MarkFlagRequired("subnet-id"); err != nil {
-		validateEgressCmd.PrintErr(err)
-	}
-
-	if err := validateEgressCmd.MarkFlagRequired("security-group-id"); err != nil {
 		validateEgressCmd.PrintErr(err)
 	}
 


### PR DESCRIPTION
## What does this PR do? / Related Issues / Jira
This PR addresses [OSD-19401](https://issues.redhat.com/browse/OSD-19401), which identifies a bug/feature gap in the AWS security groups auto-generated by osd-network-verifier (i.e., when the caller does not supply a sec. group ID). Currently, these security groups are created with a static set of rules allowing egress to TCP ports specified in the egress list (e.g., 80, 443). If the user is testing a network with a proxy configuration, this static rule set might not allow traffic to flow to the user's proxy server running on, e.g., port 8080.

This PR extends the verifier's sec. group auto-generation logic such that it adds egress rules to the base set that cover the ports used in the user-provided proxy URLs. For example, if a user passes the arguments `--http-proxy http://10.0.0.238:8080` and `--https-proxy https://10.0.0.238:8443` to the standalone network verifier binary, the verifier will generate a security group containing rules allowing egress to port 8080 and 8443. It will not affect any user-provided security groups.

For testing purposes, this PR also modifies the standalone network verifier binary such that `--security-group-id` is now optional. If not supplied by the user, an SG will be auto-generated according to the new/extended logic described above.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have tested the functionality against ~~gcp~~ / aws, it doesn't cause any regression
- [ ] I have added execution results to the PR's readme

## How to test this PR
1. Set up a test VPC that forces internet access through a basic HTTP proxy (Squid worked well for me) that runs on ports other than 80, 443, or 9997
2. Checkout this PR
3. Run the verifier, specifying proxy URL(s) but not specifying security groups, e.g.,
```
./osd-network-verifier egress --debug --subnet-id=subnet-037123dbd622cf059 --profile=default --region=us-west-2 --http-proxy=http://172.31.27.30:8080 --https-proxy=http://172.31.27.30:8443
```
4. While the verifier runs, check your AWS account and verify that the auto-created security groups contain additional rules allowing egress to your proxy's IP (CIDR ending with "/32" or "/128") and port(s).
5. Confirm verifier output is expected (i.e., not all egresses failed)

## Logs 
TBA
