### PR TITLE
OSD-19187 allow multiple SGs to be passed to Network verifier

### DIFF
--- a/cmd/egress/cmd.go
+++ b/cmd/egress/cmd.go
@@ -31,7 +31,7 @@ type egressConfig struct {
 	vpcSubnetID                string
 	cloudImageID               string
 	instanceType               string
-	securityGroupId            string
+	securityGroupIds           []string
 	cloudTags                  map[string]string
 	debug                      bool
 	region                     string
@@ -128,8 +128,8 @@ are set correctly before execution.
 
 				//Setup AWS Specific Configs
 				vei.AWS = verifier.AwsEgressConfig{
-					KmsKeyID:        config.kmsKeyID,
-					SecurityGroupId: config.securityGroupId,
+					KmsKeyID:         config.kmsKeyID,
+					SecurityGroupIds: config.securityGroupIds,
 				}
 
 				awsVerifier, err := utils.GetAwsVerifier(config.region, config.awsProfile, config.debug)
@@ -220,7 +220,7 @@ are set correctly before execution.
 	validateEgressCmd.Flags().StringVar(&config.vpcSubnetID, "subnet-id", "", "source subnet ID")
 	validateEgressCmd.Flags().StringVar(&config.cloudImageID, "image-id", "", "(optional) cloud image for the compute instance")
 	validateEgressCmd.Flags().StringVar(&config.instanceType, "instance-type", "", "(optional) compute instance type")
-	validateEgressCmd.Flags().StringVar(&config.securityGroupId, "security-group-id", "", "(optional) sec. group to attach to the created EC2 instance. If absent, one will be created")
+	validateEgressCmd.Flags().StringSliceVar(&config.securityGroupIds, "security-group-id", []string{}, "(optional) sec. group to attach to the created EC2 instance. If absent, one will be created")
 	validateEgressCmd.Flags().StringVar(&config.region, "region", "", fmt.Sprintf("(optional) compute instance region. If absent, environment var %[1]v = %[2]v and %[3]v = %[4]v will be used", awsRegionEnvVarStr, awsRegionDefault, gcpRegionEnvVarStr, gcpRegionDefault))
 	validateEgressCmd.Flags().StringToStringVar(&config.cloudTags, "cloud-tags", map[string]string{}, "(optional) comma-seperated list of tags to assign to cloud resources e.g. --cloud-tags key1=value1,key2=value2")
 	validateEgressCmd.Flags().BoolVar(&config.debug, "debug", false, "(optional) if true, enable additional debug-level logging")

--- a/pkg/verifier/aws/aws_verifier.go
+++ b/pkg/verifier/aws/aws_verifier.go
@@ -137,16 +137,16 @@ func (a *AwsVerifier) validateInstanceType(ctx context.Context, instanceType str
 }
 
 type createEC2InstanceInput struct {
-	amiID           string
-	SubnetID        string
-	userdata        string
-	KmsKeyID        string
-	securityGroupId string
-	instanceCount   int32
-	instanceType    string
-	tags            map[string]string
-	ctx             context.Context
-	keyPair         string
+	amiID            string
+	SubnetID         string
+	userdata         string
+	KmsKeyID         string
+	securityGroupIds []string
+	instanceCount    int32
+	instanceType     string
+	tags             map[string]string
+	ctx              context.Context
+	keyPair          string
 }
 
 func (a *AwsVerifier) createEC2Instance(input createEC2InstanceInput) (string, error) {
@@ -167,8 +167,8 @@ func (a *AwsVerifier) createEC2Instance(input createEC2InstanceInput) (string, e
 
 	// An empty string does not default to the default security group, and returns this error:
 	// error performing ec2:RunInstances: Value () for parameter groupId is invalid. The value cannot be empty
-	if input.securityGroupId != "" {
-		eniSpecification.Groups = []string{input.securityGroupId}
+	if len(input.securityGroupIds) > 0 {
+		eniSpecification.Groups = input.securityGroupIds
 	}
 
 	// Build our request, converting the go base types into the pointers required by the SDK

--- a/pkg/verifier/package_verifier.go
+++ b/pkg/verifier/package_verifier.go
@@ -36,7 +36,8 @@ type ValidateEgressInput struct {
 	ImportKeyPair                                      string
 }
 type AwsEgressConfig struct {
-	KmsKeyID, SecurityGroupId string
+	KmsKeyID         string
+	SecurityGroupIds []string
 }
 type GcpEgressConfig struct {
 	Region, Zone, ProjectID, VpcName string


### PR DESCRIPTION

- Enhancement/Feature

This PR allows to pass multiple security groups to network verifier in order to attach multiple SGs to the network verifier instance

<!-- Mandatory
change the sg params of the command to a slice instead of a string. 
Change the necessary functions in order to iterate through the new SGs in order to do the cleanup.
-->

## Checklist


## Reviewer's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] (This needs to be done after technical review) I've run the branch on my local, verified that the functionality is ok

## How to test this PR locally / Special Instructions

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
