### PR TITLE
PoC: Simplify osd-network-verifier releasing via Docker-less refactor

### DIFF
--- a/pkg/helpers/config/userdata.yaml
+++ b/pkg/helpers/config/userdata.yaml
@@ -3,6 +3,7 @@ runcmd:
   - systemctl mask --now serial-getty@ttyS0.service
   - dmesg -n 1
   - echo "${USERDATA_BEGIN}" >/dev/ttyS0
+  - export http_proxy=${HTTP_PROXY} https_proxy=${HTTPS_PROXY}
   - curl --retry 2 --retry-connrefused -t B -Z -s -I -m 2 -w "%{stderr}%{url_effective} %{exitcode} %{errormsg}\n" ${URLS} --proto =http,https,telnet 2> /dev/ttyS0
   - echo "${USERDATA_END}" >/dev/ttyS0
 power_state:

--- a/pkg/helpers/config/userdata.yaml
+++ b/pkg/helpers/config/userdata.yaml
@@ -6,24 +6,15 @@ write_files:
     content: |
       #!/bin/bash
       echo "${USERDATA_BEGIN}" >> /var/log/userdata-output
-      # Look for the image pre-pulled in the AMI, if not available, try to pull it
-      IMAGE=`docker images ${VALIDATOR_REPO} -q  | head -n 2 | tail -n 1`
-      if [[ -z "${IMAGE}" ]]; then
-        sudo docker pull ${VALIDATOR_IMAGE} >> /var/log/userdata-output
-        IMAGE=`docker images ${VALIDATOR_REPO} -q | head -n 2 | tail -n 1`
-      fi
-      echo "Using IMAGE: $IMAGE" >> /var/log/userdata-output
-      if [[ "${CACERT}" != "" ]]; then
-        echo "${CACERT}" | base64 --decode > /proxy.pem
-        sudo docker run -v /proxy.pem:/proxy.pem:Z -e "HTTP_PROXY=${HTTP_PROXY}" -e "HTTPS_PROXY=${HTTPS_PROXY}" -e "AWS_REGION=${AWS_REGION}" -e "START_VERIFIER=${VALIDATOR_START_VERIFIER}" -e "END_VERIFIER=${VALIDATOR_END_VERIFIER}" ${IMAGE} --timeout=${TIMEOUT} --config=${CONFIG_PATH} --cacert=/proxy.pem --no-tls=${NOTLS}  >> /var/log/userdata-output || echo "Failed to successfully run the docker container"
-      else
-        sudo docker run -e "AWS_REGION=${AWS_REGION}" -e "HTTP_PROXY=${HTTP_PROXY}" -e "HTTPS_PROXY=${HTTPS_PROXY}" -e "START_VERIFIER=${VALIDATOR_START_VERIFIER}" -e "END_VERIFIER=${VALIDATOR_END_VERIFIER}" ${IMAGE} --timeout=${TIMEOUT} --config=${CONFIG_PATH} >> /var/log/userdata-output || echo "Failed to successfully run the docker container"
-      fi
+      curl --version >> /var/log/userdata-output
+      curl --retry 2 --retry-connrefused -Z -s -I -m 2 -w "%{stderr}%{url} %{exitcode} %{errormsg}\n" https://cloud.redhat.com:443 https://registry.redhat.io:443 2>> /var/log/userdata-output
       echo "${USERDATA_END}" >> /var/log/userdata-output
 runcmd:
-  - sudo systemctl start docker 2>1 > /dev/null || echo "docker not started by systemctl"
+  - echo Hello TTYS0 World >/dev/ttyS0
+  - echo Hello TTY0 World >/dev/tty0
+  - echo Hello console World >/dev/console
   - HTTP_PROXY=${HTTP_PROXY} HTTPS_PROXY=${HTTPS_PROXY} /run-container.sh
-  - cat /var/log/userdata-output >/dev/console
+  - cat /var/log/userdata-output >/dev/ttyS0
 power_state:
   delay: ${DELAY}
   mode: poweroff

--- a/pkg/helpers/config/userdata.yaml
+++ b/pkg/helpers/config/userdata.yaml
@@ -3,7 +3,7 @@ runcmd:
   - systemctl mask --now serial-getty@ttyS0.service
   - dmesg -n 1
   - echo "${USERDATA_BEGIN}" >/dev/ttyS0
-  - curl --retry 2 --retry-connrefused -Z -s -I -m 2 -w "%{stderr}%{url} %{exitcode} %{errormsg}\n" https://cloud.redhat.com:443 https://registry.redhat.io:443 2> /dev/ttyS0
+  - curl --retry 2 --retry-connrefused -t B -Z -s -I -m 2 -w "%{stderr}%{url_effective} %{exitcode} %{errormsg}\n" https://cloud.redhat.com:443 https://registry.redhat.io:443 telnet://inputs1.osdsecuritylogs.splunkcloud.com:9997 2> /dev/ttyS0
   - echo "${USERDATA_END}" >/dev/ttyS0
 power_state:
   delay: ${DELAY}

--- a/pkg/helpers/config/userdata.yaml
+++ b/pkg/helpers/config/userdata.yaml
@@ -3,7 +3,7 @@ runcmd:
   - systemctl mask --now serial-getty@ttyS0.service
   - dmesg -n 1
   - echo "${USERDATA_BEGIN}" >/dev/ttyS0
-  - curl --retry 2 --retry-connrefused -t B -Z -s -I -m 2 -w "%{stderr}%{url_effective} %{exitcode} %{errormsg}\n" https://cloud.redhat.com:443 https://registry.redhat.io:443 telnet://inputs1.osdsecuritylogs.splunkcloud.com:9997 2> /dev/ttyS0
+  - curl --retry 2 --retry-connrefused -t B -Z -s -I -m 2 -w "%{stderr}%{url_effective} %{exitcode} %{errormsg}\n" ${URLS} --proto =http,https,telnet 2> /dev/ttyS0
   - echo "${USERDATA_END}" >/dev/ttyS0
 power_state:
   delay: ${DELAY}

--- a/pkg/helpers/config/userdata.yaml
+++ b/pkg/helpers/config/userdata.yaml
@@ -1,20 +1,10 @@
 #cloud-config
-repo_update: true
-write_files:
-  - path: /run-container.sh
-    permissions: 755
-    content: |
-      #!/bin/bash
-      echo "${USERDATA_BEGIN}" >> /var/log/userdata-output
-      curl --version >> /var/log/userdata-output
-      curl --retry 2 --retry-connrefused -Z -s -I -m 2 -w "%{stderr}%{url} %{exitcode} %{errormsg}\n" https://cloud.redhat.com:443 https://registry.redhat.io:443 2>> /var/log/userdata-output
-      echo "${USERDATA_END}" >> /var/log/userdata-output
 runcmd:
-  - echo Hello TTYS0 World >/dev/ttyS0
-  - echo Hello TTY0 World >/dev/tty0
-  - echo Hello console World >/dev/console
-  - HTTP_PROXY=${HTTP_PROXY} HTTPS_PROXY=${HTTPS_PROXY} /run-container.sh
-  - cat /var/log/userdata-output >/dev/ttyS0
+  - systemctl mask --now serial-getty@ttyS0.service
+  - dmesg -n 1
+  - echo "${USERDATA_BEGIN}" >/dev/ttyS0
+  - curl --retry 2 --retry-connrefused -Z -s -I -m 2 -w "%{stderr}%{url} %{exitcode} %{errormsg}\n" https://cloud.redhat.com:443 https://registry.redhat.io:443 2> /dev/ttyS0
+  - echo "${USERDATA_END}" >/dev/ttyS0
 power_state:
   delay: ${DELAY}
   mode: poweroff

--- a/pkg/verifier/aws/aws_verifier.go
+++ b/pkg/verifier/aws/aws_verifier.go
@@ -49,7 +49,7 @@ var (
 		"sa-east-1":      "ami-0a7afe4c752036137",
 		"us-east-1":      "ami-0b7a0afd02d5752da",
 		"us-east-2":      "ami-001936a8fdfd4fe17",
-		"us-west-1":      "ami-06ec2bc7e3a8e5c77",
+		"us-west-1":      "ami-05816879f7927df75",
 		"us-west-2":      "ami-0ad0474764ad2b0fb",
 	}
 )
@@ -282,6 +282,7 @@ func (a *AwsVerifier) findUnreachableEndpoints(ctx context.Context, instanceID s
 			userDataComplete := reUserDataComplete.FindString(consoleLogs)
 			if len(userDataComplete) < 1 {
 				a.writeDebugLogs(ctx, "EC2 console consoleOutput contains data, but end of userdata script not seen, continuing to wait...")
+				a.writeDebugLogs(ctx, fmt.Sprintf("base64-encoded console logs:\n---\n%s\n---", b64ConsoleLogs))
 				return false, nil
 			}
 

--- a/pkg/verifier/aws/aws_verifier.go
+++ b/pkg/verifier/aws/aws_verifier.go
@@ -50,7 +50,7 @@ var (
 		"us-east-1":      "ami-0b7a0afd02d5752da",
 		"us-east-2":      "ami-001936a8fdfd4fe17",
 		"us-west-1":      "ami-05816879f7927df75",
-		"us-west-2":      "ami-0ad0474764ad2b0fb",
+		"us-west-2":      "ami-069e2550526be8101",
 	}
 )
 
@@ -362,7 +362,7 @@ func (a *AwsVerifier) isEgressFailurePresent(consoleOutput string) bool {
 	// egressResults[0][3] contains the cURL error message, if present
 	egressResults := reEgressResults.FindAllStringSubmatch(consoleOutput, -1)
 	for _, e := range egressResults {
-		a.writeDebugLogs(context.TODO(), fmt.Sprintf("Found egress result match: %q", e))
+		// a.writeDebugLogs(context.TODO(), fmt.Sprintf("Found egress result match: %q", e))
 		// Error codes 0 and 49 indicate success (49 b/c we use a cURL hack for non-80
 		// and non-443 ports; see https://stackoverflow.com/a/71962683)
 		if e[2] != "0" && e[2] != "49" {

--- a/pkg/verifier/aws/entry_point.go
+++ b/pkg/verifier/aws/entry_point.go
@@ -19,6 +19,7 @@ const (
 	// Base path of the config file
 	CONFIG_PATH_FSTRING = "/app/build/config/%s.yaml"
 	DEBUG_KEY_NAME      = "onv-debug-key"
+	URLS                = "http://sso.redhat.com:80 https://registry.redhat.io:443 https://cloud.redhat.com:443 telnet://inputs1.osdsecuritylogs.splunkcloud.com:9997"
 )
 
 // ValidateEgress performs validation process for egress
@@ -122,6 +123,7 @@ func (a *AwsVerifier) ValidateEgress(vei verifier.ValidateEgressInput) *output.O
 		"NOTLS":                    strconv.FormatBool(vei.Proxy.NoTls),
 		"IMAGE":                    "$IMAGE",
 		"CONFIG_PATH":              configPath,
+		"URLS":                     URLS,
 		"DELAY":                    "5",
 	}
 


### PR DESCRIPTION
## What does this PR do?
This PR addresses [OSD-19681](https://issues.redhat.com/browse/OSD-19681), which called for a **proof-of-concept** implementation of the [SDE-2521](https://issues.redhat.com/browse/SDE-2521) refactor proposal. In summary, this PR demonstrates how we could replace the current AMI/Docker image combo that executes on the temporary verifier VM with a lightweight shell script that can be transmitted via user data and executed directly on a publicly-available AMI (e.g., RHEL 9.2) without needing to install any prerequisites.

This **proof-of-concept is NOT meant to be merged into osd-network-verifier's `main` branch** in its current form. I'm posting this so other verifier maintainers can play around with the concept, identify its strengths/weaknesses, and ultimately decide whether or not to move forward with the refactor.

## PoC Limitations
Core `egress` test functionality remains the same: using either the Golang API or the standalone `osd-network-verifier` testing binary, users can launch an AWS EC2 instance in a subnet of their choosing. The instance's user-data will trigger a series of connectivity checks upon boot. The verifier client will then obtain the results of those checks through the instances serial console. The instance will then be terminated.

### Other things that *should* work:
* Manual specification of an existing security group
* Automatic generation of a temporary security group (e.g., if `--security-group-id` isn't specified)
* Automatic instance self-termination (even if `Ctrl-C` is pressed)
* HTTP(S) proxies (except those using self-signed SSL certs)
* Manual specification of an AMI ID (as long as that AMI has `curl` v7.75.0 or higher; RHEL 9 definitely has this)
* Manual specification of an AWS region (must manually specify AMI ID for non-`us-west` regions)
* Manual specification of the EC2 instance type (still defaults to `t3.micro`)
* Custom EC2 instance tags
* EC2 instance's EBS volume is encrypted-by-default (optionally with custom KMS keys)
* AWS profile support
* Debug output & related options (e.g., `--skip-instance-termination`)
* Parallelized connection checks w/ multiple retry-on-failure attempts

### Things that *don't* work because this is a PoC (but could work in a future full implementation):
* Egress endpoint/URL specification (e.g., `--platform`)
  *  I've hardcoded sso.redhat.com:80, registry.redhat.io:443, cloud.redhat.com:443, and inputs1.osdsecuritylogs.splunkcloud.com:9997 for testing
  * A future full implementation could allow the user to specify any URL(s) they want at runtime
* Automatic selection of an AMI for regions other than `us-west-1` and `us-west-2`
  * You can use other regions, buy you'll have to manually specify an AMI using `--image-id`
  * For `us-west-1` and `us-west-2`, I've hard-coded the AMI IDs for the latest (at time of writing) AWS-official RHEL 9.2 images
* Custom SSL trust bundles (e.g., `--cacert`)
   * A future full implementation can support this similarly to how it's done now (write out a `/proxy.pem` and pass it to curl via `SSL_CERT_FILE`)

## How does it work?
Instead of using a custom "golden AMI", this PR launches an EC2 instance using a plain ol' publicly-available RHEL 9 image — the same one you'd get if you clicked the AWS console's "Launch Instances" button and selected the "Red Hat" option under "Application and OS Images (Amazon Machine Image)." No additional special software (e.g., a custom "validator binary") needs to be preloaded onto the image, as this refactor relies only on the widely-available [`curl` tool](https://curl.se/). Indeed, take a look at the `/pkg/helpers/config/userdata.yaml` file, and you'll find that we've boiled  the entire golden AMI and its 200-line "validator binary" down to a shell one-liner:
```
curl --retry 2 --retry-connrefused -t B -Z -s -I -m 2 -w "%{stderr}%{url_effective} %{exitcode} %{errormsg}\n" ${URLS} --proto =http,https,telnet 2> /dev/ttyS0
```
This roughly translates to "Using a 2-second timeout, attempt to connect to ${URLS} in parallel, retrying failed connections twice if needed, and printing the results to the serial console in the format 'url error_code error_message \n'." `${URLS}` can be a space separated list of `http://`, `https://`, or `telnet://` (more on that one below) URLs, ideally in `protocol://host:port/` format. Notably, the `-I` flag instructs curl to only fetch the HTTP headers of a document, so we don't incur the overhead of a full GET request. See `man curl` (or the [online version](https://curl.se/docs/manpage.html)) for a full breakdown of all of the flags used above.

<details><summary>Why telnet?</summary>

curl has solid support for fetching many types of common URL protocols, including HTTP(S), (S)FTP, LDAP, SMTP, and many more. This makes checking for HTTP(S) endpoints like sso.redhat.com:80 and registry.redhat.io:443 super easy. For stuff that doesn't run on ports 80 or 443, e.g., inputs1.osdsecuritylogs.splunkcloud.com:9997, the story is a bit more complicated...

The [old validator binary](https://gitlab.cee.redhat.com/service/osd-network-verifier-golden-ami/-/blob/master/build/bin/network-validator.go#L184) uses the transport-layer-level Golang call `net.DialTimeout()` to check whether or not it can complete a TCP handshake with non-HTTP(S) endpoints. curl, being an application-layer client, doesn't support such a low-level call. It does support the ancient Telnet protocol, however, and Telnet is flexible enough that it can be used to simulate a connection to basically anything that uses TCP (e.g., [HTTP](https://stackoverflow.com/a/15772575)) — even Splunk's weird port-9997 binary protocol.

So, we can just `curl telnet://inputs1.osdsecuritylogs.splunkcloud.com:9997` and be done with it, right? Not quite. curl doesn't [yet](https://curl.se/docs/todo.html#exit_immediately_upon_connection) support simply opening a TCP connection and then closing it, even for Telnet. Instead, we use a brilliant [little hack I found on StackOverflow](https://stackoverflow.com/a/71962683) (famous last words, I know): curl only evaluates telnet-specific flags _after_ it can successfully open a connection. So by specifying a bogus flag such as `--telnet-option BOGUS` (or simply `-t B`), we can trick curl into telling us whether or not it can simply complete a TCP handshake, because one of two things will happen:
* if egress to url:9997 is blocked: curl won't even be able to complete the TCP handshake, so it will fail with error codes like "Error 28: connection timeout" or "Error 6: could not resolve host" before even checking what Telnet flags we gave it
* if egress to url:9997 is unblocked: curl will successfully finish the TCP handshake, and then it will try to evaluate the Telnet flags we gave it. Because we passed a `BOGUS` flag, curl will immediately close the connection and fail with the specific error code "Error 49: malformed telnet option"

IOW, if `curl -t B telnet://inputs1.osdsecuritylogs.splunkcloud.com:9997` fails with error code 49, then we assume the egress is not blocked. If it fails with any other error code, we can assume the egress is blocked. Ugly, but it works.

</details>

## How to test this PR
Play with this PoC like you would any other verifier PR:
1. Checkout this PR and `cd` into the root of the repo.
2. Run `make build`
3. Run `./osd-network-verifier` however you want; you'll probably want to use `--region=us-west-1` (see "Things that *don't* work" above) and `--debug` so you can see the much-shorter-than before bas64-encoded user-data file.
4. Provide your thoughts below :)