### PR TITLE
Check for duplicates before adding proxy sec. group rules

### DIFF
--- a/pkg/helpers/helpers.go
+++ b/pkg/helpers/helpers.go
@@ -57,14 +57,32 @@ func IPPermissionsEquivalent(a ec2Types.IpPermission, b ec2Types.IpPermission) b
 		return false
 	}
 
-	for idx, ipRange := range a.IpRanges {
-		if *ipRange.CidrIp != *b.IpRanges[idx].CidrIp {
+	for _, ipRangeA := range a.IpRanges {
+		foundEquivalentIPRange := false
+		// Nested loop necessary to check for out-of-order IpRanges
+		for _, ipRangeB := range b.IpRanges {
+			if *ipRangeA.CidrIp == *ipRangeB.CidrIp {
+				// We only need to find one IpRange in b that matches ipRangeA, so break here
+				foundEquivalentIPRange = true
+				break
+			}
+		}
+		if !foundEquivalentIPRange {
 			return false
 		}
 	}
 
-	for idx, ipv6Range := range a.Ipv6Ranges {
-		if *ipv6Range.CidrIpv6 != *b.Ipv6Ranges[idx].CidrIpv6 {
+	for _, ipv6RangeA := range a.Ipv6Ranges {
+		foundEquivalentIPv6Range := false
+		// Nested loop necessary to check for out-of-order Ipv6Ranges
+		for _, ipv6RangeB := range b.Ipv6Ranges {
+			if *ipv6RangeA.CidrIpv6 == *ipv6RangeB.CidrIpv6 {
+				// We only need to find one Ipv6Range in b that matches ipv6RangeA, so break here
+				foundEquivalentIPv6Range = true
+				break
+			}
+		}
+		if !foundEquivalentIPv6Range {
 			return false
 		}
 	}

--- a/pkg/helpers/helpers.go
+++ b/pkg/helpers/helpers.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"math/rand"
 	"time"
+
+	ec2Types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 )
 
 //go:embed config/userdata.yaml
@@ -41,6 +43,33 @@ func PollImmediate(interval time.Duration, timeout time.Duration, condition func
 	}
 
 	return errors.New("timed out waiting for the condition")
+}
+
+// IPPermissionsEquivalent compares two AWS IpPermissions (used in security group rules)
+// similarly to reflect.DeepEqual, except it only compares IP(v6) ports and CIDR ranges
+// and ignores UserIdGroupPairs, PrefixListIds, and any Description fields
+func IPPermissionsEquivalent(a ec2Types.IpPermission, b ec2Types.IpPermission) bool {
+	if *a.FromPort != *b.FromPort || *a.ToPort != *b.ToPort || *a.IpProtocol != *b.IpProtocol {
+		return false
+	}
+
+	if len(a.IpRanges) != len(b.IpRanges) || len(a.Ipv6Ranges) != len(b.Ipv6Ranges) {
+		return false
+	}
+
+	for idx, ipRange := range a.IpRanges {
+		if *ipRange.CidrIp != *b.IpRanges[idx].CidrIp {
+			return false
+		}
+	}
+
+	for idx, ipv6Range := range a.Ipv6Ranges {
+		if *ipv6Range.CidrIpv6 != *b.Ipv6Ranges[idx].CidrIpv6 {
+			return false
+		}
+	}
+
+	return true
 }
 
 // Enumerated type representing the platform underlying the cluster-under-test

--- a/pkg/helpers/helpers_test.go
+++ b/pkg/helpers/helpers_test.go
@@ -1,0 +1,201 @@
+package helpers
+
+import (
+	_ "embed"
+	"testing"
+
+	awsTools "github.com/aws/aws-sdk-go-v2/aws"
+	ec2Types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+)
+
+func TestIPPermissionsEquivalent(t *testing.T) {
+	type args struct {
+		a ec2Types.IpPermission
+		b ec2Types.IpPermission
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "identical",
+			args: args{
+				a: ec2Types.IpPermission{
+					FromPort:   awsTools.Int32(80),
+					ToPort:     awsTools.Int32(80),
+					IpProtocol: awsTools.String("tcp"),
+					IpRanges: []ec2Types.IpRange{
+						{
+							CidrIp:      awsTools.String("0.0.0.0/0"),
+							Description: awsTools.String("foo"),
+						},
+					},
+				},
+				b: ec2Types.IpPermission{
+					FromPort:   awsTools.Int32(80),
+					ToPort:     awsTools.Int32(80),
+					IpProtocol: awsTools.String("tcp"),
+					IpRanges: []ec2Types.IpRange{
+						{
+							CidrIp:      awsTools.String("0.0.0.0/0"),
+							Description: awsTools.String("foo"),
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "equivalent diff descriptions",
+			args: args{
+				a: ec2Types.IpPermission{
+					FromPort:   awsTools.Int32(80),
+					ToPort:     awsTools.Int32(80),
+					IpProtocol: awsTools.String("tcp"),
+					IpRanges: []ec2Types.IpRange{
+						{
+							CidrIp:      awsTools.String("0.0.0.0/0"),
+							Description: awsTools.String("foo"),
+						},
+					},
+				},
+				b: ec2Types.IpPermission{
+					FromPort:   awsTools.Int32(80),
+					ToPort:     awsTools.Int32(80),
+					IpProtocol: awsTools.String("tcp"),
+					IpRanges: []ec2Types.IpRange{
+						{
+							CidrIp:      awsTools.String("0.0.0.0/0"),
+							Description: awsTools.String("bar"),
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "not equivalent port",
+			args: args{
+				a: ec2Types.IpPermission{
+					FromPort:   awsTools.Int32(8080),
+					ToPort:     awsTools.Int32(8080),
+					IpProtocol: awsTools.String("tcp"),
+					IpRanges: []ec2Types.IpRange{
+						{
+							CidrIp:      awsTools.String("0.0.0.0/0"),
+							Description: awsTools.String("foo"),
+						},
+					},
+				},
+				b: ec2Types.IpPermission{
+					FromPort:   awsTools.Int32(80),
+					ToPort:     awsTools.Int32(80),
+					IpProtocol: awsTools.String("tcp"),
+					IpRanges: []ec2Types.IpRange{
+						{
+							CidrIp:      awsTools.String("0.0.0.0/0"),
+							Description: awsTools.String("foo"),
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "not equivalent cidr",
+			args: args{
+				a: ec2Types.IpPermission{
+					FromPort:   awsTools.Int32(80),
+					ToPort:     awsTools.Int32(80),
+					IpProtocol: awsTools.String("tcp"),
+					IpRanges: []ec2Types.IpRange{
+						{
+							CidrIp:      awsTools.String("0.0.1.3/32"),
+							Description: awsTools.String("foo"),
+						},
+					},
+				},
+				b: ec2Types.IpPermission{
+					FromPort:   awsTools.Int32(80),
+					ToPort:     awsTools.Int32(80),
+					IpProtocol: awsTools.String("tcp"),
+					IpRanges: []ec2Types.IpRange{
+						{
+							CidrIp:      awsTools.String("0.0.0.0/0"),
+							Description: awsTools.String("foo"),
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "not equivalent range len",
+			args: args{
+				a: ec2Types.IpPermission{
+					FromPort:   awsTools.Int32(80),
+					ToPort:     awsTools.Int32(80),
+					IpProtocol: awsTools.String("tcp"),
+					IpRanges: []ec2Types.IpRange{
+						{
+							CidrIp:      awsTools.String("0.0.0.0/32"),
+							Description: awsTools.String("foo"),
+						},
+						{
+							CidrIp:      awsTools.String("0.0.1.3/32"),
+							Description: awsTools.String("bar"),
+						},
+					},
+				},
+				b: ec2Types.IpPermission{
+					FromPort:   awsTools.Int32(80),
+					ToPort:     awsTools.Int32(80),
+					IpProtocol: awsTools.String("tcp"),
+					IpRanges: []ec2Types.IpRange{
+						{
+							CidrIp:      awsTools.String("0.0.0.0/32"),
+							Description: awsTools.String("foo"),
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "not equivalent v6",
+			args: args{
+				a: ec2Types.IpPermission{
+					FromPort:   awsTools.Int32(80),
+					ToPort:     awsTools.Int32(80),
+					IpProtocol: awsTools.String("tcp"),
+					Ipv6Ranges: []ec2Types.Ipv6Range{
+						{
+							CidrIpv6:    awsTools.String("ff06::c3/128"),
+							Description: awsTools.String("foo"),
+						},
+					},
+				},
+				b: ec2Types.IpPermission{
+					FromPort:   awsTools.Int32(80),
+					ToPort:     awsTools.Int32(80),
+					IpProtocol: awsTools.String("tcp"),
+					Ipv6Ranges: []ec2Types.Ipv6Range{
+						{
+							CidrIpv6:    awsTools.String("ff06::c5/128"),
+							Description: awsTools.String("foo"),
+						},
+					},
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IPPermissionsEquivalent(tt.args.a, tt.args.b); got != tt.want {
+				t.Errorf("IPPermissionsEquivalent() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/helpers/helpers_test.go
+++ b/pkg/helpers/helpers_test.go
@@ -75,6 +75,78 @@ func TestIPPermissionsEquivalent(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "equivalent diff iprange ordering",
+			args: args{
+				a: ec2Types.IpPermission{
+					FromPort:   awsTools.Int32(80),
+					ToPort:     awsTools.Int32(80),
+					IpProtocol: awsTools.String("tcp"),
+					IpRanges: []ec2Types.IpRange{
+						{
+							CidrIp:      awsTools.String("1.1.1.1/23"),
+							Description: awsTools.String("foo"),
+						},
+						{
+							CidrIp:      awsTools.String("2.2.2.2/34"),
+							Description: awsTools.String("foo"),
+						},
+					},
+				},
+				b: ec2Types.IpPermission{
+					FromPort:   awsTools.Int32(80),
+					ToPort:     awsTools.Int32(80),
+					IpProtocol: awsTools.String("tcp"),
+					IpRanges: []ec2Types.IpRange{
+						{
+							CidrIp:      awsTools.String("2.2.2.2/34"),
+							Description: awsTools.String("foo"),
+						},
+						{
+							CidrIp:      awsTools.String("1.1.1.1/23"),
+							Description: awsTools.String("foo"),
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "equivalent diff ipv6range ordering",
+			args: args{
+				a: ec2Types.IpPermission{
+					FromPort:   awsTools.Int32(80),
+					ToPort:     awsTools.Int32(80),
+					IpProtocol: awsTools.String("tcp"),
+					Ipv6Ranges: []ec2Types.Ipv6Range{
+						{
+							CidrIpv6:    awsTools.String("ff06::c5/128"),
+							Description: awsTools.String("foo"),
+						},
+						{
+							CidrIpv6:    awsTools.String("ff03::c1/128"),
+							Description: awsTools.String("bar"),
+						},
+					},
+				},
+				b: ec2Types.IpPermission{
+					FromPort:   awsTools.Int32(80),
+					ToPort:     awsTools.Int32(80),
+					IpProtocol: awsTools.String("tcp"),
+					Ipv6Ranges: []ec2Types.Ipv6Range{
+						{
+							CidrIpv6:    awsTools.String("ff03::c1/128"),
+							Description: awsTools.String("bar"),
+						},
+						{
+							CidrIpv6:    awsTools.String("ff06::c5/128"),
+							Description: awsTools.String("foo"),
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
 			name: "not equivalent port",
 			args: args{
 				a: ec2Types.IpPermission{

--- a/pkg/verifier/aws/aws_verifier.go
+++ b/pkg/verifier/aws/aws_verifier.go
@@ -8,7 +8,6 @@ import (
 	"net/netip"
 	"net/url"
 	"os"
-	"reflect"
 	"regexp"
 	"strconv"
 	"time"
@@ -597,10 +596,9 @@ func ipPermissionSetFromURLs(ipURLStrs []string, ipPermDescriptionPrefix string)
 			return nil, fmt.Errorf("unable to create security group rule from URL '%s': %w", ipURLStr, err)
 		}
 		// Add ipPerm to ipPermissions only if not already there (AWS will reject duplicates)
-		// FIXME: we need a DeepEqual that disregards mismatching descriptions, otherwise bug on edge case where two URLS with different protos but same host:port are passed
 		ipPermAlreadyExists := false
 		for _, existingIPPerm := range ipPermissionSet {
-			ipPermAlreadyExists = ipPermAlreadyExists || reflect.DeepEqual(*ipPerm, existingIPPerm)
+			ipPermAlreadyExists = ipPermAlreadyExists || helpers.IPPermissionsEquivalent(*ipPerm, existingIPPerm)
 		}
 		if !ipPermAlreadyExists {
 			ipPermissionSet = append(ipPermissionSet, *ipPerm)

--- a/pkg/verifier/aws/aws_verifier_test.go
+++ b/pkg/verifier/aws/aws_verifier_test.go
@@ -375,7 +375,28 @@ func Test_ipPermissionSetFromURLs(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "multiple identical URLs",
+			args: args{
+				ipURLStrs:               []string{"http://1.2.3.4:567", "http://1.2.3.4:567"},
+				ipPermDescriptionPrefix: "multi-identical test: ",
+			},
+			want: []ec2Types.IpPermission{
+				{
+					FromPort:   awss.Int32(567),
+					ToPort:     awss.Int32(567),
+					IpProtocol: awss.String("tcp"),
+					IpRanges: []ec2Types.IpRange{
+						{
+							CidrIp:      awss.String("1.2.3.4/32"),
+							Description: awss.String("multi-identical test: http://1.2.3.4:567"),
+						},
+					},
+				},
+			},
+		},
 	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := ipPermissionSetFromURLs(tt.args.ipURLStrs, tt.args.ipPermDescriptionPrefix)


### PR DESCRIPTION
## What does this PR do?
This PR addresses a bug in #202's implementation of [OSD-19401](https://issues.redhat.com/browse/OSD-19401). The original implementation did not check for equality between the HTTP and HTTPS proxy URLs passed by the user/caller, leading `AllowSecurityGroupProxyEgress()` to generate duplicate security rules that get rejected by the AWS API. This bugfix adds set-like behavior where new security group rules are checked against existing ones before being added to the AuthorizeSecurityGroupEgress AWS API call.

## Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have tested the functionality against ~~gcp~~ / aws, it doesn't cause any regression
- [x] I have added execution results to the PR's readme

## How to test this PR
1. Set up a test VPC that forces internet access through a basic HTTP proxy (Squid worked well for me) that runs on ports other than 80, 443, or 9997
2. Checkout this PR, `cd` into the root of the repo, and run `make test` and `make build`
3. Run the verifier, specifying **two equivalent proxy URLs** but not specifying security groups, e.g.,
```
./osd-network-verifier egress --debug --subnet-id=subnet-037123dbd622cf059 --profile=default --region=us-west-2 --http-proxy=http://172.31.27.30:8080 --https-proxy=https://172.31.27.30:8080
```
4. While the verifier runs, check your AWS account and verify that the auto-created security groups contains **one single additional rule** allowing egress to your proxy's IP (CIDR ending with "/32" or "/128") and port.
5. Confirm verifier output is expected (i.e., not all egresses failed)

## Logs 
```
$ ./osd-network-verifier egress --debug --subnet-id=subnet-037123dbd622cf059 --profile=default --region=us-west-2 --http-proxy=http://172.31.27.30:8080 --https-proxy=https://172.31.27.30:8080
Using region: us-west-2
Using configured timeout of 2s for each egress request
Gathering description of instance type t3.micro from EC2
using config file: /app/build/config/aws.yaml
base64-encoded generated userdata script:
---
[base64 redacted for length]
---
Creating a Security group
Waiting for the Security Group to exist: sg-0278ee0ec24c4c995
Created security group with ID: sg-0278ee0ec24c4c995
Created instance with ID: i-0b917bbf97613627a
Scraping console output and waiting for user data script to complete...
EC2 console consoleOutput contains data, but end of userdata script not seen, continuing to wait...
EC2 console consoleOutput contains data, but end of userdata script not seen, continuing to wait...
base64-encoded console logs:                                                                                                                                                                                         
---
[base64 redacted for length]
---
 - egress failures found

printing out failures:
 - egressURL error: inputs1.osdsecuritylogs.splunkcloud.com:9997

printing out exceptions preventing the verifier from running the specific test:
printing out errors faced during the execution:
Failure!
```