### PR TITLE
Address security group leak with earlier `defer` call

### DIFF
--- a/cmd/egress/cmd.go
+++ b/cmd/egress/cmd.go
@@ -31,8 +31,8 @@ type egressConfig struct {
 	vpcSubnetID                string
 	cloudImageID               string
 	instanceType               string
-	securityGroupId            string // Deprecated: prefer securityGroupIds
-	securityGroupIds           []string
+	securityGroupId            string // Deprecated: prefer securityGroupIDs
+	securityGroupIDs           []string
 	cloudTags                  map[string]string
 	debug                      bool
 	region                     string
@@ -131,7 +131,7 @@ are set correctly before execution.
 				vei.AWS = verifier.AwsEgressConfig{
 					KmsKeyID:         config.kmsKeyID,
 					SecurityGroupId:  config.securityGroupId,
-					SecurityGroupIds: config.securityGroupIds,
+					SecurityGroupIDs: config.securityGroupIDs,
 				}
 
 				awsVerifier, err := utils.GetAwsVerifier(config.region, config.awsProfile, config.debug)
@@ -223,7 +223,7 @@ are set correctly before execution.
 	validateEgressCmd.Flags().StringVar(&config.cloudImageID, "image-id", "", "(optional) cloud image for the compute instance")
 	validateEgressCmd.Flags().StringVar(&config.instanceType, "instance-type", "", "(optional) compute instance type")
 	validateEgressCmd.Flags().StringVar(&config.securityGroupId, "security-group-id", "", "(deprecated in favor of --security-group-ids)")
-	validateEgressCmd.Flags().StringSliceVar(&config.securityGroupIds, "security-group-ids", []string{}, "(optional) comma-separated list of sec. group IDs to attach to the created EC2 instance. If absent, one will be created")
+	validateEgressCmd.Flags().StringSliceVar(&config.securityGroupIDs, "security-group-ids", []string{}, "(optional) comma-separated list of sec. group IDs to attach to the created EC2 instance. If absent, one will be created")
 	validateEgressCmd.Flags().StringVar(&config.region, "region", "", fmt.Sprintf("(optional) compute instance region. If absent, environment var %[1]v = %[2]v and %[3]v = %[4]v will be used", awsRegionEnvVarStr, awsRegionDefault, gcpRegionEnvVarStr, gcpRegionDefault))
 	validateEgressCmd.Flags().StringToStringVar(&config.cloudTags, "cloud-tags", map[string]string{}, "(optional) comma-seperated list of tags to assign to cloud resources e.g. --cloud-tags key1=value1,key2=value2")
 	validateEgressCmd.Flags().BoolVar(&config.debug, "debug", false, "(optional) if true, enable additional debug-level logging")

--- a/cmd/egress/cmd.go
+++ b/cmd/egress/cmd.go
@@ -31,8 +31,8 @@ type egressConfig struct {
 	vpcSubnetID                string
 	cloudImageID               string
 	instanceType               string
-	securityGroupId            string
-	securityGroupsIds          []string
+	securityGroupId            string // Deprecated: prefer securityGroupIds
+	securityGroupIds           []string
 	cloudTags                  map[string]string
 	debug                      bool
 	region                     string
@@ -129,9 +129,9 @@ are set correctly before execution.
 
 				//Setup AWS Specific Configs
 				vei.AWS = verifier.AwsEgressConfig{
-					KmsKeyID:          config.kmsKeyID,
-					SecurityGroupId:   config.securityGroupId,
-					SecurityGroupsIds: config.securityGroupsIds,
+					KmsKeyID:         config.kmsKeyID,
+					SecurityGroupId:  config.securityGroupId,
+					SecurityGroupIds: config.securityGroupIds,
 				}
 
 				awsVerifier, err := utils.GetAwsVerifier(config.region, config.awsProfile, config.debug)
@@ -222,8 +222,8 @@ are set correctly before execution.
 	validateEgressCmd.Flags().StringVar(&config.vpcSubnetID, "subnet-id", "", "source subnet ID")
 	validateEgressCmd.Flags().StringVar(&config.cloudImageID, "image-id", "", "(optional) cloud image for the compute instance")
 	validateEgressCmd.Flags().StringVar(&config.instanceType, "instance-type", "", "(optional) compute instance type")
-	validateEgressCmd.Flags().StringVar(&config.securityGroupId, "security-group-id", "", "(optional) sec. group to attach to the created EC2 instance. If absent, one will be created (Deprecated)")
-	validateEgressCmd.Flags().StringSliceVar(&config.securityGroupsIds, "security-groups-ids", []string{}, "(Optional) Takes a list of security groups to attach to the created EC2 instance.")
+	validateEgressCmd.Flags().StringVar(&config.securityGroupId, "security-group-id", "", "(deprecated in favor of --security-group-ids)")
+	validateEgressCmd.Flags().StringSliceVar(&config.securityGroupIds, "security-group-ids", []string{}, "(optional) comma-separated list of sec. group IDs to attach to the created EC2 instance. If absent, one will be created")
 	validateEgressCmd.Flags().StringVar(&config.region, "region", "", fmt.Sprintf("(optional) compute instance region. If absent, environment var %[1]v = %[2]v and %[3]v = %[4]v will be used", awsRegionEnvVarStr, awsRegionDefault, gcpRegionEnvVarStr, gcpRegionDefault))
 	validateEgressCmd.Flags().StringToStringVar(&config.cloudTags, "cloud-tags", map[string]string{}, "(optional) comma-seperated list of tags to assign to cloud resources e.g. --cloud-tags key1=value1,key2=value2")
 	validateEgressCmd.Flags().BoolVar(&config.debug, "debug", false, "(optional) if true, enable additional debug-level logging")
@@ -243,6 +243,6 @@ are set correctly before execution.
 	}
 
 	//Mark securityGroupId and securityGroupsIDs flags as mutually exclusive (one or the other should be passed, not both).
-	validateEgressCmd.MarkFlagsMutuallyExclusive("security-group-id", "security-groups-ids")
+	validateEgressCmd.MarkFlagsMutuallyExclusive("security-group-id", "security-group-ids")
 	return validateEgressCmd
 }

--- a/docs/aws/aws.md
+++ b/docs/aws/aws.md
@@ -155,7 +155,7 @@ repeat the verification process for each subnet ID.
         --platform string             (optional) infra platform type, which determines which endpoints to test. Either 'aws', 'gcp', or 'hostedcluster' (hypershift) (default "aws")
         --profile string              (optional) AWS profile. If present, any credentials passed with CLI will be ignored
         --region string               (optional) compute instance region. If absent, environment var AWS_REGION = us-east-2 and GCP_REGION = us-east1 will be used
-        --security-group-id string    security group ID to attach to the created EC2 instance
+        --security-group-ids strings  (optional) comma-separated list of sec. group IDs to attach to the created EC2 instance. If absent, one will be created
         --skip-termination            (optional) Skip instance termination to allow further debugging
         --subnet-id string            source subnet ID
         --terminate-debug string      (optional) Takes the debug instance ID and terminates it

--- a/examples/aws/verify_egress.go
+++ b/examples/aws/verify_egress.go
@@ -60,7 +60,7 @@ func extendValidateEgress() {
 		Proxy:        p,
 		AWS: verifier.AwsEgressConfig{
 			KmsKeyID:         "kmskeyID",
-			SecurityGroupIds: []string{"SecurityGroupId1", "OptionalSecurityGroupId2"},
+			SecurityGroupIDs: []string{"SecurityGroupID1", "OptionalSecurityGroupID2"},
 		},
 		PlatformType: helpers.PlatformAWS,
 	}

--- a/examples/aws/verify_egress.go
+++ b/examples/aws/verify_egress.go
@@ -59,8 +59,8 @@ func extendValidateEgress() {
 		InstanceType: "m5.2xlarge",
 		Proxy:        p,
 		AWS: verifier.AwsEgressConfig{
-			KmsKeyID:        "kmskeyID",
-			SecurityGroupId: "SecurityGroupId",
+			KmsKeyID:         "kmskeyID",
+			SecurityGroupIds: []string{"SecurityGroupId1", "OptionalSecurityGroupId2"},
 		},
 		PlatformType: helpers.PlatformAWS,
 	}

--- a/pkg/verifier/aws/aws_verifier.go
+++ b/pkg/verifier/aws/aws_verifier.go
@@ -141,8 +141,8 @@ type createEC2InstanceInput struct {
 	SubnetID         string
 	userdata         string
 	KmsKeyID         string
-	securityGroupId  string // Deprecated: prefer securityGroupIds
-	securityGroupIds []string
+	securityGroupId  string // Deprecated: prefer securityGroupIDs
+	securityGroupIDs []string
 	instanceCount    int32
 	instanceType     string
 	tags             map[string]string
@@ -172,8 +172,8 @@ func (a *AwsVerifier) createEC2Instance(input createEC2InstanceInput) (string, e
 		eniSpecification.Groups = []string{input.securityGroupId}
 	}
 
-	if len(input.securityGroupIds) > 0 {
-		eniSpecification.Groups = input.securityGroupIds
+	if len(input.securityGroupIDs) > 0 {
+		eniSpecification.Groups = input.securityGroupIDs
 	}
 
 	// Build our request, converting the go base types into the pointers required by the SDK

--- a/pkg/verifier/aws/aws_verifier.go
+++ b/pkg/verifier/aws/aws_verifier.go
@@ -137,17 +137,17 @@ func (a *AwsVerifier) validateInstanceType(ctx context.Context, instanceType str
 }
 
 type createEC2InstanceInput struct {
-	amiID             string
-	SubnetID          string
-	userdata          string
-	KmsKeyID          string
-	securityGroupId   string
-	securityGroupsIDs []string
-	instanceCount     int32
-	instanceType      string
-	tags              map[string]string
-	ctx               context.Context
-	keyPair           string
+	amiID            string
+	SubnetID         string
+	userdata         string
+	KmsKeyID         string
+	securityGroupId  string // Deprecated: prefer securityGroupIds
+	securityGroupIds []string
+	instanceCount    int32
+	instanceType     string
+	tags             map[string]string
+	ctx              context.Context
+	keyPair          string
 }
 
 func (a *AwsVerifier) createEC2Instance(input createEC2InstanceInput) (string, error) {
@@ -172,8 +172,8 @@ func (a *AwsVerifier) createEC2Instance(input createEC2InstanceInput) (string, e
 		eniSpecification.Groups = []string{input.securityGroupId}
 	}
 
-	if len(input.securityGroupsIDs) > 0 {
-		eniSpecification.Groups = input.securityGroupsIDs
+	if len(input.securityGroupIds) > 0 {
+		eniSpecification.Groups = input.securityGroupIds
 	}
 
 	// Build our request, converting the go base types into the pointers required by the SDK

--- a/pkg/verifier/aws/entry_point.go
+++ b/pkg/verifier/aws/entry_point.go
@@ -141,7 +141,6 @@ func (a *AwsVerifier) ValidateEgress(vei verifier.ValidateEgressInput) *output.O
 	}
 
 	// If security group not given, create a temporary one
-	cleanupSecurityGroup := false
 	if vei.AWS.SecurityGroupId == "" && len(vei.AWS.SecurityGroupsIds) == 0 {
 		vpcId, err := a.GetVpcIdFromSubnetId(vei.Ctx, vei.SubnetID)
 		if err != nil {
@@ -152,8 +151,10 @@ func (a *AwsVerifier) ValidateEgress(vei verifier.ValidateEgressInput) *output.O
 		if err != nil {
 			return a.Output.AddError(err)
 		}
-		cleanupSecurityGroup = true
 		vei.AWS.SecurityGroupId = *createSecurityGroupOutput.GroupId
+
+		// Now that security group has been created, ensure we clean it up
+		defer CleanupSecurityGroup(vei, a)
 
 		// If proxy information given, add rules for it to the security group
 		if vei.Proxy.HttpProxy != "" || vei.Proxy.HttpsProxy != "" {
@@ -190,23 +191,20 @@ func (a *AwsVerifier) ValidateEgress(vei verifier.ValidateEgressInput) *output.O
 		securityGroupsIDs: vei.AWS.SecurityGroupsIds,
 		keyPair:           vei.ImportKeyPair,
 	})
-
-	//If securitygroup was created by network-verifier, delete it as part of cleanup
-	if cleanupSecurityGroup {
-		defer CleanupSecurityGroup(vei, a)
+	if err != nil {
+		return a.Output.AddError(err)
 	}
 
-	if err != nil {
+	// Run the result fetcher, which will store egress failures in a.Output.failures
+	if err := a.findUnreachableEndpoints(vei.Ctx, instanceID); err != nil {
 		a.Output.AddError(err)
-	} else {
-		if err := a.findUnreachableEndpoints(vei.Ctx, instanceID); err != nil {
-			a.Output.AddError(err)
-		}
+		// Don't return yet; still need to terminate instance
+	}
 
-		if !vei.SkipInstanceTermination {
-			if err := a.AwsClient.TerminateEC2Instance(vei.Ctx, instanceID); err != nil {
-				a.Output.AddError(err)
-			}
+	// Terminate the EC2 instance (unless user requests otherwise)
+	if !vei.SkipInstanceTermination {
+		if err := a.AwsClient.TerminateEC2Instance(vei.Ctx, instanceID); err != nil {
+			a.Output.AddError(err)
 		}
 	}
 

--- a/pkg/verifier/aws/entry_point.go
+++ b/pkg/verifier/aws/entry_point.go
@@ -141,7 +141,7 @@ func (a *AwsVerifier) ValidateEgress(vei verifier.ValidateEgressInput) *output.O
 	}
 
 	// If security group not given, create a temporary one
-	if vei.AWS.SecurityGroupId == "" && len(vei.AWS.SecurityGroupsIds) == 0 {
+	if vei.AWS.SecurityGroupId == "" && len(vei.AWS.SecurityGroupIds) == 0 {
 		vpcId, err := a.GetVpcIdFromSubnetId(vei.Ctx, vei.SubnetID)
 		if err != nil {
 			return a.Output.AddError(err)
@@ -179,17 +179,17 @@ func (a *AwsVerifier) ValidateEgress(vei verifier.ValidateEgressInput) *output.O
 
 	// Create EC2 instance
 	instanceID, err := a.createEC2Instance(createEC2InstanceInput{
-		amiID:             vei.CloudImageID,
-		SubnetID:          vei.SubnetID,
-		userdata:          userData,
-		KmsKeyID:          vei.AWS.KmsKeyID,
-		instanceCount:     instanceCount,
-		ctx:               vei.Ctx,
-		instanceType:      vei.InstanceType,
-		tags:              vei.Tags,
-		securityGroupId:   vei.AWS.SecurityGroupId,
-		securityGroupsIDs: vei.AWS.SecurityGroupsIds,
-		keyPair:           vei.ImportKeyPair,
+		amiID:            vei.CloudImageID,
+		SubnetID:         vei.SubnetID,
+		userdata:         userData,
+		KmsKeyID:         vei.AWS.KmsKeyID,
+		instanceCount:    instanceCount,
+		ctx:              vei.Ctx,
+		instanceType:     vei.InstanceType,
+		tags:             vei.Tags,
+		securityGroupId:  vei.AWS.SecurityGroupId,
+		securityGroupIds: vei.AWS.SecurityGroupIds,
+		keyPair:          vei.ImportKeyPair,
 	})
 	if err != nil {
 		return a.Output.AddError(err)

--- a/pkg/verifier/aws/entry_point.go
+++ b/pkg/verifier/aws/entry_point.go
@@ -141,7 +141,7 @@ func (a *AwsVerifier) ValidateEgress(vei verifier.ValidateEgressInput) *output.O
 	}
 
 	// If security group not given, create a temporary one
-	if vei.AWS.SecurityGroupId == "" && len(vei.AWS.SecurityGroupIds) == 0 {
+	if vei.AWS.SecurityGroupId == "" && len(vei.AWS.SecurityGroupIDs) == 0 {
 		vpcId, err := a.GetVpcIdFromSubnetId(vei.Ctx, vei.SubnetID)
 		if err != nil {
 			return a.Output.AddError(err)
@@ -188,7 +188,7 @@ func (a *AwsVerifier) ValidateEgress(vei verifier.ValidateEgressInput) *output.O
 		instanceType:     vei.InstanceType,
 		tags:             vei.Tags,
 		securityGroupId:  vei.AWS.SecurityGroupId,
-		securityGroupIds: vei.AWS.SecurityGroupIds,
+		securityGroupIDs: vei.AWS.SecurityGroupIDs,
 		keyPair:          vei.ImportKeyPair,
 	})
 	if err != nil {

--- a/pkg/verifier/package_verifier.go
+++ b/pkg/verifier/package_verifier.go
@@ -37,8 +37,8 @@ type ValidateEgressInput struct {
 }
 type AwsEgressConfig struct {
 	KmsKeyID         string
-	SecurityGroupId  string // Deprecated: prefer securityGroupIds
-	SecurityGroupIds []string
+	SecurityGroupId  string // Deprecated: prefer securityGroupIDs
+	SecurityGroupIDs []string
 }
 type GcpEgressConfig struct {
 	Region, Zone, ProjectID, VpcName string

--- a/pkg/verifier/package_verifier.go
+++ b/pkg/verifier/package_verifier.go
@@ -36,8 +36,9 @@ type ValidateEgressInput struct {
 	ImportKeyPair                                      string
 }
 type AwsEgressConfig struct {
-	KmsKeyID, SecurityGroupId string
-	SecurityGroupsIds         []string
+	KmsKeyID         string
+	SecurityGroupId  string // Deprecated: prefer securityGroupIds
+	SecurityGroupIds []string
 }
 type GcpEgressConfig struct {
 	Region, Zone, ProjectID, VpcName string


### PR DESCRIPTION
## What does this PR do?
This PR addresses bug [OSD-19998](https://issues.redhat.com/browse/OSD-19998), which reported security group (SG) leakage in certain code paths involving automatic SG creation. In summary, if an AWS API error was encountered between the creation of the SG and the creation of the EC2 instance, the network-verifier would exit/return without cleaning up it's auto-generated SG. This is fixed by calling `defer CleanupSecurityGroup()` earlier in the code, ensuring that the SG cleanup function is run in almost all cases. This PR also performs some general code cleanup, including clearer documentation of the deprecation of the `--security-group-id`/`securityGroupId` parameter and making the use of its successor, `--security-group-ids`/`SecurityGroupIDs`, more consistent across the codebase.

Note that this PR does not cover paths involving instance termination timeouts or the user pressing Ctrl-C, as these situations are out-of-scope for [OSD-19998](https://issues.redhat.com//browse/OSD-19998).

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the ~~default configuration~~ example code files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have tested the functionality against ~~gcp~~ / aws, it doesn't cause any regression
- [ ] I have added execution results to the PR's readme

## How to test this PR
1. In your AWS dev account, create a "rigged" IAM user with a policy that allows everything the verifier needs, except for `ec2::AuthorizeSecurityGroupEgress`
2. Generate/install credentials for this test user on your machine (e.g., under a new `rigged` profile in `~/.aws/credentials`)
3. Clone this repo, navigate to root it, checkout this PR
4. Run `make build`
5. Run `./osd-network-verifier egress --debug` as you normally would, but use the rigged credentials (e.g., `--profile=rigged`) and _don't_ use the `--security-group-id[s]` flags (so you force the verifier to generate a security group for you)
6. Observe the verifier reach the "Creating a Security group" stage, and then fail
7. Use the AWS web console to verify that no "osd-network-verifier*" security group was left behind
8. Check CloudTrail to ensure the temp. security group was both created and deleted