### PR TITLE
Added t3.micro as default fallback when non nitro instances are chose…

### DIFF
--- a/cmd/egress/cmd.go
+++ b/cmd/egress/cmd.go
@@ -221,7 +221,7 @@ are set correctly before execution.
 	validateEgressCmd.Flags().StringVar(&config.platformType, "platform", platformTypeDefault, fmt.Sprintf("(optional) infra platform type, which determines which endpoints to test. Either '%v', '%v', or '%v' (hypershift)", helpers.PlatformAWS, helpers.PlatformGCP, helpers.PlatformHostedCluster))
 	validateEgressCmd.Flags().StringVar(&config.vpcSubnetID, "subnet-id", "", "source subnet ID")
 	validateEgressCmd.Flags().StringVar(&config.cloudImageID, "image-id", "", "(optional) cloud image for the compute instance")
-	validateEgressCmd.Flags().StringVar(&config.instanceType, "instance-type", "", "(optional) compute instance type")
+	validateEgressCmd.Flags().StringVar(&config.instanceType, "instance-type", "t3.micro", "(optional) compute instance type")
 	validateEgressCmd.Flags().StringVar(&config.securityGroupId, "security-group-id", "", "(deprecated in favor of --security-group-ids)")
 	validateEgressCmd.Flags().StringSliceVar(&config.securityGroupIDs, "security-group-ids", []string{}, "(optional) comma-separated list of sec. group IDs to attach to the created EC2 instance. If absent, one will be created")
 	validateEgressCmd.Flags().StringVar(&config.region, "region", "", fmt.Sprintf("(optional) compute instance region. If absent, environment var %[1]v = %[2]v and %[3]v = %[4]v will be used", awsRegionEnvVarStr, awsRegionDefault, gcpRegionEnvVarStr, gcpRegionDefault))

--- a/pkg/verifier/aws/aws_verifier.go
+++ b/pkg/verifier/aws/aws_verifier.go
@@ -129,7 +129,7 @@ func (a *AwsVerifier) validateInstanceType(ctx context.Context, instanceType str
 
 	if string(descOut.InstanceTypes[0].InstanceType) == instanceType {
 		if descOut.InstanceTypes[0].Hypervisor != ec2Types.InstanceTypeHypervisorNitro {
-			return fmt.Errorf("instance type %s must use hypervisor type 'nitro' to support reliable result collection, using %s", instanceType, descOut.InstanceTypes[0].Hypervisor)
+			return fmt.Errorf("probe instances must use 'nitro' hypervisor to support reliable result collection, but %s uses '%s'", instanceType, descOut.InstanceTypes[0].Hypervisor)
 		}
 	}
 

--- a/pkg/verifier/aws/entry_point.go
+++ b/pkg/verifier/aws/entry_point.go
@@ -30,15 +30,12 @@ const (
 func (a *AwsVerifier) ValidateEgress(vei verifier.ValidateEgressInput) *output.Output {
 	a.writeDebugLogs(vei.Ctx, fmt.Sprintf("Using configured timeout of %s for each egress request", vei.Timeout.String()))
 
-	// Set default instance type if non is found
-	if vei.InstanceType == "" {
-		vei.InstanceType = "t3.micro"
-	}
-
 	// Validates the provided instance type will work with the verifier
 	// NOTE a "nitro" EC2 instance type is required to be used
 	if err := a.validateInstanceType(vei.Ctx, vei.InstanceType); err != nil {
-		return a.Output.AddError(fmt.Errorf("instance type %s is invalid: %s", vei.InstanceType, err))
+		fmt.Printf("Warning. instance type %s is invalid: %s. Using default %s instance type instead\n", vei.InstanceType, err, "t3.micro")
+
+		vei.InstanceType = "t3.micro"
 	}
 
 	// Select config file based on platform type


### PR DESCRIPTION
Added t3.micro as default fallback when non nitro instances are chose…

<!-- Type of change
- Enhancement
-->

## What does this PR do? / Related Issues / Jira
https://issues.redhat.com/browse/OSD-20512

<!-- Mandatory
Made t3.micro the default intance type for the network verifier instance, including when non nitro hypervisor instance types are passed. changed the fail to a warning output message-->



