### PR TITLE
fix a bug introduced with the describe security Group  filters

### DIFF
--- a/pkg/verifier/aws/entry_point.go
+++ b/pkg/verifier/aws/entry_point.go
@@ -144,12 +144,12 @@ func (a *AwsVerifier) ValidateEgress(vei verifier.ValidateEgressInput) *output.O
 	}
 
 	// If security group not given, create a temporary one
-	var VpcId string
+	VpcId, err := a.GetVpcIdFromSubnetId(vei.Ctx, vei.SubnetID)
+	if err != nil {
+		return a.Output.AddError(err)
+	}
+
 	if vei.AWS.SecurityGroupId == "" && len(vei.AWS.SecurityGroupIDs) == 0 {
-		VpcId, err = a.GetVpcIdFromSubnetId(vei.Ctx, vei.SubnetID)
-		if err != nil {
-			return a.Output.AddError(err)
-		}
 
 		createSecurityGroupOutput, err := a.CreateSecurityGroup(vei.Ctx, vei.Tags, "osd-network-verifier", VpcId)
 		if err != nil {


### PR DESCRIPTION
fix a bug introduced where the describe security Group  filters were built with empty value for VpcID

<!-- Type of change
-Bug
-->

## What does this PR do? / Related Issues / Jira
make sure the VpcId always has a value. extracted from the if that executed only when we dont use a --security-group-id flag. Now we always have the VpcId which we need in other parts of the code.

