### PR TITLE
Align OWNERS with re-org

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,21 +1,20 @@
 reviewers:
-- robotmaxtron
-- fahlmant
-- lnguyen1401
-- tiwillia
-- boranx
-- bng0y
-- ritmun
-- abyrne55
-- anispate
-- mjlshen
+  - AlexVulaj
+  - abyrne55
+  - reedcort
+  - dakotalongRH
+  - lnguyen1401
+  - luis-falcon
+  - mjlshen
 approvers:
-- fahlmant
-- bng0y
-- boranx
-- bdematte
-- rafael-azevedo
-- mjlshen
+  - abyrne55
+  - rafael-azevedo
+  - fahlmant
+  - mjlshen
+emeritus_approvers:
+  - bng0y
+  - boranx
+  - bdematte
 maintainers:
-- fahlmant
-- bng0y
+  - abyrne55
+  - fahlmant


### PR DESCRIPTION
This PR updates OWNERS such that it aligns with the recent team re-org. I've set `reviewers` ~= Team Aurora. I've also moved `approvers` no longer involved with the project to [`emeritus_approvers`](https://www.kubernetes.dev/docs/guide/owners/#emeritus). Finally, I added myself and Raf as `approvers`, and set the symbolic `maintainers` to myself and fahlmant.

Open to feedback 😃 
