### PR TITLE
Update release process docs and AMI images

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -14,8 +14,10 @@ These changes don't automatically mean a change is a breaking or significant cha
 
 For now, this is mostly manual. It's important to validate that these scenarios are working before making a new release:
 
-* The `networkValidatorImage` in [./pkg/verifier/aws/aws_verifier.go](./pkg/verifier/aws/aws_verifier.go) is the same image that is pre-baked on the `defaultAMI`'s.
-* The integration test in [./integration](./integration) is run using the `aws` and `hostedcluster` configurations
+* The `defaultAmi` mapping values in [/pkg/verifier/aws/aws_verifier.go](./pkg/verifier/aws/aws_verifier.go) should be updated to match what is in the console output for the [most recent golden-ami build](https://ci.int.devshift.net/job/gl-build-master-osd-network-verifier-golden-ami-packer/).
+  * Note - if the above build is broken due to `ResourceLimitExceeded` issues, you will have to manually clean up the AMI image repository by following [this SOP](https://github.com/openshift/ops-sop/blob/master/v4/howto/network-verifier/clean-golden-ami.md), and then re-running the Jenkins build.
+* The `networkValidatorImage` in [./pkg/verifier/aws/aws_verifier.go](./pkg/verifier/aws/aws_verifier.go) is the same image that is pre-baked on the `defaultAMI`'s. This can be found by looking at the latest tagged image in the [osd-network-verifier quay repository](https://quay.io/repository/app-sre/osd-network-verifier?tab=tags&tag=latest).
+* Build the `integration` binary by running `go build` from the `/integration` folder. Then use this binary to test both the `aws` and `hostedcluster` configurations as shown below. For more information on setting up integration tests, see the [integration README](./integration/README.md).
   * `./integration --platform aws`
   * `./integration --platform hostedcluster`
 * egress test in AWS with a cluster-wide proxy

--- a/pkg/verifier/aws/aws_verifier.go
+++ b/pkg/verifier/aws/aws_verifier.go
@@ -24,33 +24,33 @@ import (
 
 var (
 	defaultAmi = map[string]string{
-		"af-south-1":     "ami-0e7e90f5a8557b8d6",
-		"ap-east-1":      "ami-05ee050a367ee5706",
-		"ap-northeast-1": "ami-06dbf6a7ef9bdf2c8",
-		"ap-northeast-2": "ami-0ac7bd07966247f41",
-		"ap-northeast-3": "ami-0968392f31285f459",
-		"ap-south-1":     "ami-0267d03e3be0b4b30",
-		"ap-south-2":     "ami-065289e536d1deb01",
-		"ap-southeast-1": "ami-0e0969b268859d182",
-		"ap-southeast-2": "ami-0d60430c78bce7d3c",
-		"ap-southeast-3": "ami-021732d200600f0b6",
-		"ap-southeast-4": "ami-02104deba0d784ce4",
-		"ca-central-1":   "ami-0b2112eb85d66f9cc",
-		"eu-central-1":   "ami-0f986a55e68070796",
-		"eu-central-2":   "ami-01dc09a6de621911a",
-		"eu-north-1":     "ami-0885df175cdf6787c",
-		"eu-south-1":     "ami-0490bacb9a4ae3a48",
-		"eu-south-2":     "ami-094214242f055b327",
-		"eu-west-1":      "ami-0342c86a5bf8d4623",
-		"eu-west-2":      "ami-0d5e499ba9bd84270",
-		"eu-west-3":      "ami-058c17d5e11588a34",
-		"me-central-1":   "ami-01cb10ec79305596a",
-		"me-south-1":     "ami-02d9162d2610a38e6",
-		"sa-east-1":      "ami-0a7afe4c752036137",
-		"us-east-1":      "ami-0b7a0afd02d5752da",
-		"us-east-2":      "ami-001936a8fdfd4fe17",
-		"us-west-1":      "ami-06ec2bc7e3a8e5c77",
-		"us-west-2":      "ami-0ad0474764ad2b0fb",
+		"af-south-1":     "ami-0fb813e1ae84400dc",
+		"ap-east-1":      "ami-03675d7e574833abe",
+		"ap-northeast-1": "ami-05cb7c7408d8f8af5",
+		"ap-northeast-2": "ami-0098483ae1ee42c0c",
+		"ap-northeast-3": "ami-0f0dbacc1707e8e72",
+		"ap-south-1":     "ami-09df79d5449429266",
+		"ap-south-2":     "ami-00b9508600f3c9b8c",
+		"ap-southeast-1": "ami-0f60e0a6e923c6e26",
+		"ap-southeast-2": "ami-099f7aa368cdddaf2",
+		"ap-southeast-3": "ami-0d5b956b53547034d",
+		"ap-southeast-4": "ami-05ce614e1f422c490",
+		"ca-central-1":   "ami-0f3fb8f365e3c9d04",
+		"eu-central-1":   "ami-002c65646f16240ec",
+		"eu-central-2":   "ami-0574dce5e80837334",
+		"eu-north-1":     "ami-0b46fc8467a79338b",
+		"eu-south-1":     "ami-0bf3ba79256d10416",
+		"eu-south-2":     "ami-0e138ecef804de823",
+		"eu-west-1":      "ami-06f8d5f267ca93271",
+		"eu-west-2":      "ami-0e0887773436969a3",
+		"eu-west-3":      "ami-055729ed70bddefb1",
+		"me-central-1":   "ami-0bf8f8a8ab2d21b1b",
+		"me-south-1":     "ami-0c7ad534496c975df",
+		"sa-east-1":      "ami-0ade9565de9880d8f",
+		"us-east-1":      "ami-0fe43a0c5a276b868",
+		"us-east-2":      "ami-0f78163a5208aae5f",
+		"us-west-1":      "ami-0ce38aa057fca4dc2",
+		"us-west-2":      "ami-0d445fea90102f683",
 	}
 )
 
@@ -59,13 +59,13 @@ const (
 
 	// TODO find a location for future docker images
 	// This corresponds with the tag: v0.1.73-b096215
-	networkValidatorImage = "quay.io/app-sre/osd-network-verifier@sha256:cb0822c72cd970675d79a58e1c3fbe2d6e703f6417fc3fdf961664800030ac73"
+	networkValidatorImage = "quay.io/app-sre/osd-network-verifier@sha256:c459ade8b55bb3df7789e3a4943cc6fc64e87879abab145a1b938bb6a1c52911"
 	networkValidatorRepo  = "quay.io/app-sre/osd-network-verifier"
 	userdataEndVerifier   = "USERDATA END"
 	prepulledImageMessage = "Warning: could not pull the specified docker image, will try to use the prepulled one"
 )
 
-// AwsVerifier holds an aws client and knows how to fuifill the VerifierSerice which contains all functions needed for verifier
+// AwsVerifier holds an aws client and knows how to fulfill the VerifierService which contains all functions needed for verifier
 type AwsVerifier struct {
 	AwsClient *aws.Client
 	Logger    ocmlog.Logger


### PR DESCRIPTION
- Enhancement/Feature

## What does this PR do? / Related Issues / Jira
Updates docs around releasing and also fixes a bug with resource cleanup in integration tests.

## Logs 

Error I was seeing from cleanup:
```
panic: operation error EC2: DeleteVpc, https response error StatusCode: 400, RequestID: 3ee80c4a-badb-415a-9b95-f568cf795270, api error DependencyViolation: The vpc 'vpc-0fa551f9b466b36a6' has dependencies and cannot be deleted.
```

When I went and looked at the VPC in AWS, there was still a security group attached.
