### PR TITLE
Cleanup security groups during integration test cleanup

### DIFF
--- a/integration/pkg/aws/aws.go
+++ b/integration/pkg/aws/aws.go
@@ -104,6 +104,7 @@ func (id *OnvIntegrationTestData) Cleanup(ctx context.Context) error {
 		id.CleanupElasticIp,
 		id.CleanupInternetGateway,
 		id.CleanupSubnets,
+		id.CleanupSecurityGroup,
 		id.CleanupVpc,
 	}); err != nil {
 		return err

--- a/integration/pkg/aws/ec2.go
+++ b/integration/pkg/aws/ec2.go
@@ -40,6 +40,9 @@ type byovpcEc2Api interface {
 	DeleteRouteTable(ctx context.Context, params *ec2.DeleteRouteTableInput, optFns ...func(*ec2.Options)) (*ec2.DeleteRouteTableOutput, error)
 	DeleteSubnet(ctx context.Context, params *ec2.DeleteSubnetInput, optFns ...func(*ec2.Options)) (*ec2.DeleteSubnetOutput, error)
 	DeleteVpc(ctx context.Context, params *ec2.DeleteVpcInput, optFns ...func(*ec2.Options)) (*ec2.DeleteVpcOutput, error)
+
+	DescribeSecurityGroups(ctx context.Context, params *ec2.DescribeSecurityGroupsInput, optFns ...func(options *ec2.Options)) (*ec2.DescribeSecurityGroupsOutput, error)
+	DeleteSecurityGroup(ctx context.Context, params *ec2.DeleteSecurityGroupInput, optFns ...func(options *ec2.Options)) (*ec2.DeleteSecurityGroupOutput, error)
 }
 
 func (id *OnvIntegrationTestData) createAndWaitForSubnet(ctx context.Context, name string, input *ec2.CreateSubnetInput) (*string, error) {


### PR DESCRIPTION
- Enhancement/Feature

## What does this PR do? / Related Issues / Jira
During resource cleanup, integration tests fail to delete a VPC if there are dangling security groups attached. This change will make sure that those security groups are

## How to test this PR locally / Special Instructions

## Logs 

These logs used to appear during cleanup:
```
panic: operation error EC2: DeleteVpc, https response error StatusCode: 400, RequestID: 3ee80c4a-badb-415a-9b95-f568cf795270, api error DependencyViolation: The vpc 'vpc-0fa551f9b466b36a6' has dependencies and cannot be deleted.
```
This change will fix that error.