### PR TITLE
enabled IMDSv2 service for the network verifier instance

### DIFF
--- a/pkg/verifier/aws/aws_verifier.go
+++ b/pkg/verifier/aws/aws_verifier.go
@@ -203,6 +203,11 @@ func (a *AwsVerifier) createEC2Instance(input createEC2InstanceInput) (string, e
 				Tags:         buildTags(input.tags),
 			},
 		},
+		//enable IMDSv2 for instances
+		MetadataOptions: &ec2Types.InstanceMetadataOptionsRequest{
+			HttpTokens:   ec2Types.HttpTokensStateRequired,
+			HttpEndpoint: ec2Types.InstanceMetadataEndpointStateEnabled,
+		},
 		UserData: awsTools.String(input.userdata),
 	}
 


### PR DESCRIPTION
<!-- Type of change
- Enhancement/Feature
-->

## What does this PR do? / Related Issues / Jira
https://issues.redhat.com/browse/OSD-20983

Enables instance Metadata service v2 on the ec2 instance created by the network verifier. The IMDSv2 introduces session-oriented requests, which adds defense in depth against unauthorized metadata access. This will not make big change on the network verifier instance at the moment since we do not request any metadata about the instance. But if at some point we do we can just call the same IMDSv1  IP url for it but now with an authentication token.

## Checklist

<!-- Mandatory
Test the network verifier and make sure that in the instance details the IMDSv2 service is set to required.
-->

