### PR TITLE
Updated egress lists documentationt o point to correct line for registering new platform types

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Golden AMI provides the following:
 
 ### Egress Lists
 
-This lists of essential domains for egress verification should be maintained in the [GitLab repo](https://gitlab.cee.redhat.com/service/osd-network-verifier-golden-ami/-/blob/master/build/config/). Newly-added lists should be registered as "platform types" in [`helpers.go`](pkg/helpers/helpers.go#L46) using the list file's extensionless name as the value (e.g., abc.yaml should be registered as `PlatformABC     string = "abc"`). Finally, the `--platform` help message and value handling logic in [`cmd.go`](cmd/egress/cmd.go) should also be updated.
+This lists of essential domains for egress verification should be maintained in the [GitLab repo](https://gitlab.cee.redhat.com/service/osd-network-verifier-golden-ami/-/blob/master/build/config/). Newly-added lists should be registered as "platform types" in [`helpers.go`](pkg/helpers/helpers.go#L94) using the list file's extensionless name as the value (e.g., abc.yaml should be registered as `PlatformABC     string = "abc"`). Finally, the `--platform` help message and value handling logic in [`cmd.go`](cmd/egress/cmd.go) should also be updated.
 
 ### IAM Permission Requirement List
 


### PR DESCRIPTION
The target file in the diff has been changed such that [Line 46](https://github.com/openshift/osd-network-verifier/blob/main/pkg/helpers/helpers.go#L46) is no longer accurate for the location of platform types variables. They now live on [Line 94](https://github.com/openshift/osd-network-verifier/blob/main/pkg/helpers/helpers.go#L94).