### PR TITLE
Update platform type names

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -18,8 +18,8 @@ For now, this is mostly manual. It's important to validate that these scenarios 
   * Note - if the above build is broken due to `ResourceLimitExceeded` issues, you will have to manually clean up the AMI image repository by following [this SOP](https://github.com/openshift/ops-sop/blob/master/v4/howto/network-verifier/clean-golden-ami.md), and then re-running the Jenkins build.
 * The `networkValidatorImage` in [./pkg/verifier/aws/aws_verifier.go](./pkg/verifier/aws/aws_verifier.go) is the same image that is pre-baked on the `defaultAMI`'s. This can be found by looking at the latest tagged image in the [osd-network-verifier quay repository](https://quay.io/repository/app-sre/osd-network-verifier?tab=tags&tag=latest).
 * Build the `integration` binary by running `go build` from the `/integration` folder. Then use this binary to test both the `aws` and `hostedcluster` configurations as shown below. For more information on setting up integration tests, see the [integration README](./integration/README.md).
-  * `./integration --platform aws`
-  * `./integration --platform hostedcluster`
+  * `./integration --platform aws-classic`
+  * `./integration --platform aws-hcp`
 * egress test in AWS with a cluster-wide proxy
 * ~~egress test on GCP~~ This should be added back when GCP support is functional again
 

--- a/docs/aws/aws.md
+++ b/docs/aws/aws.md
@@ -134,11 +134,11 @@ repeat the verification process for each subnet ID.
 
        ```shell        
       # using AWS profile on an OSD/ROSA cluster
-      ./osd-network-verifier egress --platform aws --subnet-id $SUBNET_ID --profile $AWS_PROFILE
+      ./osd-network-verifier egress --platform aws-classic --subnet-id $SUBNET_ID --profile $AWS_PROFILE
       
       # using AWS secret on a HyperShift hosted cluster
         AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY  \
-      ./osd-network-verifier egress --platform hostedcluster --subnet-id $SUBNET_ID  
+      ./osd-network-verifier egress --platform aws-hcp --subnet-id $SUBNET_ID  
         ```
    
         Additional optional flags for overriding defaults:
@@ -152,7 +152,7 @@ repeat the verification process for each subnet ID.
         --instance-type string        (optional) compute instance type
         --kms-key-id string           (optional) ID of KMS key used to encrypt root volumes of compute instances. Defaults to cloud account default key
         --no-tls                      (optional) if true, skip client-side SSL certificate validation
-        --platform string             (optional) infra platform type, which determines which endpoints to test. Either 'aws', 'gcp', or 'hostedcluster' (hypershift) (default "aws")
+        --platform string              (optional) infra platform type, which determines which endpoints to test. Either 'aws-classic', 'gcp-classic', or 'hosted-cp' (hypershift) (default "aws-hcp")
         --profile string              (optional) AWS profile. If present, any credentials passed with CLI will be ignored
         --region string               (optional) compute instance region. If absent, environment var AWS_REGION = us-east-2 and GCP_REGION = us-east1 will be used
         --security-group-ids strings  (optional) comma-separated list of sec. group IDs to attach to the created EC2 instance. If absent, one will be created
@@ -160,7 +160,7 @@ repeat the verification process for each subnet ID.
         --subnet-id string            source subnet ID
         --terminate-debug string      (optional) Takes the debug instance ID and terminates it
         --timeout duration            (optional) timeout for individual egress verification requests (default 2s)
-        --vpc-name string             (optional unless --platform='gcp') VPC name where GCP cluster is installed
+        --vpc-name string             (optional unless --platform='gcp-classic') VPC name where GCP cluster is installed
         ```
    
        Get cli help:

--- a/docs/gcp/gcp.md
+++ b/docs/gcp/gcp.md
@@ -58,7 +58,7 @@ repeat the verification process for each subnet ID.
 
        ```shell        
       # GCP
-      ./osd-network-verifier egress --gcp --subnet-id $SUBNET_ID 
+      ./osd-network-verifier egress --platform gcp-classic --subnet-id $SUBNET_ID 
       
         Additional optional flags for overriding defaults (image-id, kms-key will be added in the future):
       ```shell

--- a/pkg/helpers/helpers.go
+++ b/pkg/helpers/helpers.go
@@ -9,6 +9,16 @@ import (
 	ec2Types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 )
 
+// Enumerated type representing the platform underlying the cluster-under-test
+const (
+	PlatformAWS           = "aws"           // deprecated: use PlatformAWSClassic
+	PlatformGCP           = "gcp"           // deprecated: use PlatformGCPClassic
+	PlatformHostedCluster = "hostedcluster" // deprecated: use PlatformAWSHCP
+	PlatformAWSClassic    = "aws-classic"
+	PlatformGCPClassic    = "gcp-classic"
+	PlatformAWSHCP        = "aws-hcp"
+)
+
 //go:embed config/userdata.yaml
 var UserdataTemplate string
 
@@ -90,9 +100,15 @@ func IPPermissionsEquivalent(a ec2Types.IpPermission, b ec2Types.IpPermission) b
 	return true
 }
 
-// Enumerated type representing the platform underlying the cluster-under-test
-const (
-	PlatformAWS           string = "aws"
-	PlatformGCP           string = "gcp"
-	PlatformHostedCluster string = "hostedcluster"
-)
+func GetPlatformType(platformType string) (string, error) {
+	switch platformType {
+	case PlatformAWS, PlatformAWSClassic:
+		return "aws", nil
+	case PlatformGCP, PlatformGCPClassic:
+		return "gcp", nil
+	case PlatformHostedCluster, PlatformAWSHCP:
+		return "hostedcluster", nil
+	default:
+		return "", errors.New("invalid platform type")
+	}
+}

--- a/pkg/helpers/helpers_test.go
+++ b/pkg/helpers/helpers_test.go
@@ -271,3 +271,67 @@ func TestIPPermissionsEquivalent(t *testing.T) {
 		})
 	}
 }
+
+func TestGetPlatformType(t *testing.T) {
+	tests := []struct {
+		name         string
+		platformType string
+		want         string
+		wantErr      bool
+	}{
+		{
+			name:         "Platform type aws",
+			platformType: PlatformAWS,
+			want:         "aws",
+			wantErr:      false,
+		},
+		{
+			name:         "Platform type gcp",
+			platformType: PlatformGCP,
+			want:         "gcp",
+			wantErr:      false,
+		},
+		{
+			name:         "Platform type hostedcluster",
+			platformType: PlatformHostedCluster,
+			want:         "hostedcluster",
+			wantErr:      false,
+		},
+		{
+			name:         "Platform type aws-classic",
+			platformType: PlatformAWSClassic,
+			want:         "aws",
+			wantErr:      false,
+		},
+		{
+			name:         "Platform type gcp-classic",
+			platformType: PlatformGCPClassic,
+			want:         "gcp",
+			wantErr:      false,
+		},
+		{
+			name:         "Platform type aws-hcp",
+			platformType: PlatformAWSHCP,
+			want:         "hostedcluster",
+			wantErr:      false,
+		},
+		{
+			name:         "Invalid platform type",
+			platformType: "foobar",
+			want:         "",
+			wantErr:      true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetPlatformType(tt.platformType)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetPlatformType() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("GetPlatformType() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- Refactoring

https://issues.redhat.com/browse/OSD-20380

## What does this PR do? / Related Issues / Jira
Deprecates platform type names "aws", "hostedcluster", and "gcp" in favor of "aws-classic", "aws-hcp", and "gcp-classic" respectively.

## Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have tested the functionality against gcp / aws, it doesn't cause any regression
- [ ] I have added execution results to the PR's readme

## How to test this PR locally / Special Instructions
1. Set up an AWS account configured with a VPC, firewall, or other components you wish to verify.
  - can be accomplished by running the `./integration` binary in `--create-only` mode.
2. run `make build` from the project's root directory
3. run `./network-verifier egress --platform rosa-classic --subnet-id <public subnet ID> --security-group-ids <security group associated to VPC> --profile <your aws profile>` and note your results.
4. run `./network-verifier egress --platform aws--subnet-id <public subnet ID> --security-group-ids <security group associated to VPC> --profile <your aws profile>` and verify results are identical to previous run.