### PR TITLE
added --force-temp-security-group flag

### DIFF
--- a/cmd/egress/cmd.go
+++ b/cmd/egress/cmd.go
@@ -48,6 +48,7 @@ type egressConfig struct {
 	skipAWSInstanceTermination bool
 	terminateDebugInstance     string
 	importKeyPair              string
+	ForceTempSecurityGroup     bool
 }
 
 func getDefaultRegion(platformType string) string {
@@ -145,6 +146,7 @@ are set correctly before execution.
 				vei.SkipInstanceTermination = config.skipAWSInstanceTermination
 				vei.TerminateDebugInstance = config.terminateDebugInstance
 				vei.ImportKeyPair = config.importKeyPair
+				vei.ForceTempSecurityGroup = config.ForceTempSecurityGroup
 
 				out := verifier.ValidateEgress(awsVerifier, vei)
 				out.Summary(config.debug)
@@ -238,6 +240,7 @@ are set correctly before execution.
 	validateEgressCmd.Flags().BoolVar(&config.skipAWSInstanceTermination, "skip-termination", false, "(optional) Skip instance termination to allow further debugging")
 	validateEgressCmd.Flags().StringVar(&config.terminateDebugInstance, "terminate-debug", "", "(optional) Takes the debug instance ID and terminates it")
 	validateEgressCmd.Flags().StringVar(&config.importKeyPair, "import-keypair", "", "(optional) Takes the path to your public key used to connect to Debug Instance. Automatically skips Termination")
+	validateEgressCmd.Flags().BoolVar(&config.ForceTempSecurityGroup, "force-temp-security-group", false, "(optional) Enforces creation of Temporary SG even if --security-group-ids flag is used")
 	if err := validateEgressCmd.MarkFlagRequired("subnet-id"); err != nil {
 		validateEgressCmd.PrintErr(err)
 	}

--- a/pkg/verifier/package_verifier.go
+++ b/pkg/verifier/package_verifier.go
@@ -34,11 +34,13 @@ type ValidateEgressInput struct {
 	SkipInstanceTermination                            bool
 	TerminateDebugInstance                             string
 	ImportKeyPair                                      string
+	ForceTempSecurityGroup                             bool
 }
 type AwsEgressConfig struct {
-	KmsKeyID         string
-	SecurityGroupId  string // Deprecated: prefer securityGroupIDs
-	SecurityGroupIDs []string
+	KmsKeyID          string
+	SecurityGroupId   string // Deprecated: prefer securityGroupIDs
+	SecurityGroupIDs  []string
+	TempSecurityGroup string
 }
 type GcpEgressConfig struct {
 	Region, Zone, ProjectID, VpcName string


### PR DESCRIPTION
#type of change
- Enhancement/Feature


## What does this PR do? / Related Issues / Jira
https://issues.redhat.com/browse/OSD-20969


Added a --force-temp-security-group flag that will force the creation of a security group to attach to the instance whenever this flag is passed (whether we pass with flags other security groups or not).


## Checklist


Run network verifier with the following flags
1 ) "--force-temp-security-group " and "--security-group-id" (expected 2 SGs to be attached to instance, the temp and the passed. The created one to be cleaned at the end).).

2) "--force-temp-security-group " and "--security-group-ids" (expected all SGs passed and the newly created one to be attached to instance, and the created one to be cleaned at the end).

3) if all the 3 flags are passed an error since the security-group-id and security-group-ids flags are are mutually exclusive.

4) if no security group flags are passed, then the default is to create a new SG to attach to instance whether we pass the "--force-temp-security-group" flag or not.

5) Integration tests must pass.


## Reviewer's Checklist

Follow the 5 steps above to test.
## How to test this PR locally / Special Instructions


Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.

Review the previous 5 steps
