### PR TITLE
Bump AMI/image IDs and fix bugs in preparation for next release

### DIFF
--- a/integration/main.go
+++ b/integration/main.go
@@ -102,7 +102,7 @@ func onvEgressCheck(cfg aws.Config, platform, subnetId string) error {
 	// Call egress validator
 	log.Println("Starting ONV egress validation")
 	out := verifier.ValidateEgress(awsVerifier, vei)
-	out.Summary(false)
+	out.Summary(true)
 	egressFailures := out.GetEgressURLFailures()
 	for _, ef := range egressFailures {
 		log.Printf("egress failure: %s", ef.EgressURL())

--- a/pkg/helpers/config/userdata.yaml
+++ b/pkg/helpers/config/userdata.yaml
@@ -2,7 +2,7 @@
 repo_update: true
 write_files:
   - path: /run-container.sh
-    permissions: 755
+    permissions: "0755"
     content: |
       #!/bin/bash
       echo "${USERDATA_BEGIN}" >> /var/log/userdata-output

--- a/pkg/verifier/aws/aws_verifier.go
+++ b/pkg/verifier/aws/aws_verifier.go
@@ -25,33 +25,33 @@ import (
 
 var (
 	defaultAmi = map[string]string{
-		"af-south-1":     "ami-0fb813e1ae84400dc",
-		"ap-east-1":      "ami-03675d7e574833abe",
-		"ap-northeast-1": "ami-05cb7c7408d8f8af5",
-		"ap-northeast-2": "ami-0098483ae1ee42c0c",
-		"ap-northeast-3": "ami-0f0dbacc1707e8e72",
-		"ap-south-1":     "ami-09df79d5449429266",
-		"ap-south-2":     "ami-00b9508600f3c9b8c",
-		"ap-southeast-1": "ami-0f60e0a6e923c6e26",
-		"ap-southeast-2": "ami-099f7aa368cdddaf2",
-		"ap-southeast-3": "ami-0d5b956b53547034d",
-		"ap-southeast-4": "ami-05ce614e1f422c490",
-		"ca-central-1":   "ami-0f3fb8f365e3c9d04",
-		"eu-central-1":   "ami-002c65646f16240ec",
-		"eu-central-2":   "ami-0574dce5e80837334",
-		"eu-north-1":     "ami-0b46fc8467a79338b",
-		"eu-south-1":     "ami-0bf3ba79256d10416",
-		"eu-south-2":     "ami-0e138ecef804de823",
-		"eu-west-1":      "ami-06f8d5f267ca93271",
-		"eu-west-2":      "ami-0e0887773436969a3",
-		"eu-west-3":      "ami-055729ed70bddefb1",
-		"me-central-1":   "ami-0bf8f8a8ab2d21b1b",
-		"me-south-1":     "ami-0c7ad534496c975df",
-		"sa-east-1":      "ami-0ade9565de9880d8f",
-		"us-east-1":      "ami-0fe43a0c5a276b868",
-		"us-east-2":      "ami-0f78163a5208aae5f",
-		"us-west-1":      "ami-0ce38aa057fca4dc2",
-		"us-west-2":      "ami-0d445fea90102f683",
+		"af-south-1":     "ami-05536c6c4a06f5aea",
+		"ap-east-1":      "ami-08b345aed9a96b8b7",
+		"ap-northeast-1": "ami-033a4e5f3afe27edf",
+		"ap-northeast-2": "ami-0fe73b2c9f2f1372d",
+		"ap-northeast-3": "ami-0bd7b986bc2ee9151",
+		"ap-south-1":     "ami-011b92e65dd17511f",
+		"ap-south-2":     "ami-0b2490e04d6513b0b",
+		"ap-southeast-1": "ami-06cffce12885b1d3e",
+		"ap-southeast-2": "ami-08d55f583e913b783",
+		"ap-southeast-3": "ami-06d6cadd186407054",
+		"ap-southeast-4": "ami-0ffd0742c1c493f39",
+		"ca-central-1":   "ami-0c4720a664da9a1f5",
+		"eu-central-1":   "ami-02bd3740ebe461600",
+		"eu-central-2":   "ami-072046f6c4c1e5f08",
+		"eu-north-1":     "ami-0bd69440ffa91dca2",
+		"eu-south-1":     "ami-0e7bab803f8a0766b",
+		"eu-south-2":     "ami-0a220f6ce8c56c88a",
+		"eu-west-1":      "ami-0c0f1b341bf0440b6",
+		"eu-west-2":      "ami-0cfa63ed96c47eaaa",
+		"eu-west-3":      "ami-0ff8234bfc530caa1",
+		"me-central-1":   "ami-0c66cc8d2f584145f",
+		"me-south-1":     "ami-052c1427d40aeb550",
+		"sa-east-1":      "ami-0237bf5ab9c7a6b30",
+		"us-east-1":      "ami-0cd1878f22de20cb8",
+		"us-east-2":      "ami-07bea2f81c034729d",
+		"us-west-1":      "ami-07730208b4254d21f",
+		"us-west-2":      "ami-0f847722087ed39a1",
 	}
 )
 
@@ -95,8 +95,8 @@ const (
 	instanceCount int32 = 1
 
 	// TODO find a location for future docker images
-	// This corresponds with the tag: v0.1.73-b096215
-	networkValidatorImage = "quay.io/app-sre/osd-network-verifier@sha256:c459ade8b55bb3df7789e3a4943cc6fc64e87879abab145a1b938bb6a1c52911"
+	// This corresponds with the quay tag: v0.1.84-00c5352
+	networkValidatorImage = "quay.io/app-sre/osd-network-verifier@sha256:8b0adab149c562bb3f0e9aaa682278fc5651b047e0173043b2b7722e16851955"
 	networkValidatorRepo  = "quay.io/app-sre/osd-network-verifier"
 	userdataEndVerifier   = "USERDATA END"
 	prepulledImageMessage = "Warning: could not pull the specified docker image, will try to use the prepulled one"

--- a/pkg/verifier/aws/entry_point.go
+++ b/pkg/verifier/aws/entry_point.go
@@ -45,8 +45,12 @@ func (a *AwsVerifier) ValidateEgress(vei verifier.ValidateEgressInput) *output.O
 	}
 
 	// Select config file based on platform type
-	configPath := fmt.Sprintf(CONFIG_PATH_FSTRING, vei.PlatformType)
-	if vei.PlatformType == "" {
+	platformTypeStr, err := helpers.GetPlatformType(vei.PlatformType)
+	if err != nil {
+		return a.Output.AddError(err)
+	}
+	configPath := fmt.Sprintf(CONFIG_PATH_FSTRING, platformTypeStr)
+	if platformTypeStr == "" {
 		// Default to AWS
 		configPath = fmt.Sprintf(CONFIG_PATH_FSTRING, helpers.PlatformAWS)
 	}


### PR DESCRIPTION
This PR updates the default AMI IDs and Quay image IDs to their latest values per our [release documentation](https://github.com/openshift/osd-network-verifier/blob/main/RELEASE.md). AMI IDs were pulled from [Jenkins build 58](https://ci.int.devshift.net/job/gl-build-master-osd-network-verifier-golden-ami-packer/58/console).

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- [x] I have made corresponding change to the default configuration files
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have tested the functionality against ~~gcp~~ / aws, it doesn't cause any regression
- ~~[ ] I have added execution results to the PR's readme~~

## How to test this PR locally
I suggest running `make build`, `make test`, and integration tests for both "aws-classic" and  "aws-hcp" platform types. While the integration tests are running, ensure recently-added features (e.g., IMDSv2, no redirect following) are working as intended.