### PR TITLE
Add version info on build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,17 @@ include project.mk
 include boilerplate/generated-includes.mk
 
 GOFLAGS=-mod=mod
+VERSION:=`git describe --tags --abbrev=0`
+COMMIT:=`git rev-parse HEAD`
+SHORTCOMMIT:=`git rev-parse --short HEAD`
+PREFIX=github.com/openshift/osd-network-verifier/version
+LDFLAGS=-ldflags="-X '$(PREFIX).Version=$(VERSION)' -X '$(PREFIX).CommitHash=$(COMMIT)' -X '$(PREFIX).ShortCommitHash=$(SHORTCOMMIT)'"
 
 .PHONY: build
 build:
 	go fmt ./...
 	go mod tidy
-	go build $(GOFLAGS) .
+	go build $(LDFLAGS) $(GOFLAGS) .
 
 .PHONY: fmt
 fmt:

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,33 +3,38 @@ package cmd
 import (
 	"flag"
 	"fmt"
-	"os"
-
 	"github.com/openshift/osd-network-verifier/cmd/dns"
 	"github.com/openshift/osd-network-verifier/cmd/egress"
+	"github.com/openshift/osd-network-verifier/version"
 	"github.com/spf13/cobra"
+	"os"
 )
 
-// GitCommit is the short git commit hash from the environment
-var GitCommit string
-
-// Version is the tag version from the environment
-var Version string
+type verifierOptions struct {
+	debug bool
+}
 
 // NewCmdRoot represents the base command when called without any subcommands
 func NewCmdRoot() *cobra.Command {
+	opts := verifierOptions{}
 	rootCmd := &cobra.Command{
 		Use:     "osd-network-verifier",
 		Example: "./osd-network-verifier [command] [flags]",
-		Version: fmt.Sprintf("%s, GitCommit: %s", Version, GitCommit),
 		Short:   "OSD network verifier CLI",
+		Version: fmt.Sprintf("%v@%v", version.Version, version.ShortCommitHash),
 		Long: `CLI tool for pre-flight verification of VPC configuration against OSD requirements. 
 For more information see https://github.com/openshift/osd-network-verifier/blob/main/README.md`,
 		DisableAutoGenTag: true,
-		Run:               help,
+		PersistentPreRun: func(*cobra.Command, []string) {
+			if opts.debug {
+				fmt.Printf("Version:\t%v\nCommit Hash:\t%v\n", version.Version, version.CommitHash)
+			}
+		},
+		Run: help,
 	}
 
 	rootCmd.PersistentFlags().AddGoFlagSet(flag.CommandLine)
+	rootCmd.PersistentFlags().BoolVar(&opts.debug, "debug", false, "")
 
 	// add sub commands
 	rootCmd.AddCommand(egress.NewCmdValidateEgress())

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,7 @@
+package version
+
+var (
+	Version         string
+	CommitHash      string
+	ShortCommitHash string
+)


### PR DESCRIPTION
- Enhancement/Feature

## What does this PR do? / Related Issues / Jira
Adds version information on build that can be accessed via `--debug` and `--version` flags. _These will only be available when directly running a built binary of network verifier_.

## Checklist

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have tested the functionality against gcp / aws, it doesn't cause any regression
- [ ] I have added execution results to the PR's readme

## How to test this PR locally / Special Instructions

```
$ ./osd-network-verifier --version                 
osd-network-verifier version v0.4.11@46fefcb

$ ./osd-network-verifier --debug
Version:        v0.4.11
Commit Hash:    46fefcbfcc7a5b4c64595f6711af6a5ce2d1211f
...
```
