### PR TITLE
[OSD-24207] Updated logic to delete oldest image of each type per region

### DIFF
--- a/cleangoldenami/README.md
+++ b/cleangoldenami/README.md
@@ -1,8 +1,8 @@
 # osd-network-verifier clean golden ami
 
-This module contains a Go script
-that will loop through each region supported by the verifier
-and delete the oldest public AMI if the resource quota is at capacity.
+This module includes a Go script that loops through each region supported by the verifier. 
+It determines the public image quota limit for each region and ensures there is space for at least three new public images: one for the legacy binary on AMD architecture, one for the curl binary (base RHEL9) on AMD architecture, and another for the curl binary on ARM architecture. 
+The script prioritizes deleting the oldest image from the image type with the most available images until the public image count for that region has enough space for three new images.
 
 ## Usage
 

--- a/cleangoldenami/go.mod
+++ b/cleangoldenami/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/osd-network-verifier/cleangoldenami
 
-go 1.22.0
+go 1.22
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.26.1

--- a/cleangoldenami/main.go
+++ b/cleangoldenami/main.go
@@ -19,6 +19,7 @@ const (
 	serviceCode          = "ec2"
 	quotaCode            = "L-0E3CBAB9"
 	timeLayout           = "2006-01-02T15:04:05.000Z"
+    // desiredImageCapacity is the number of free "image slots" desired in each region
 	desiredImageCapacity = 3
 )
 

--- a/cleangoldenami/main.go
+++ b/cleangoldenami/main.go
@@ -60,12 +60,12 @@ func main() {
 				log.Fatalf("error fetching images for region %v: %v", regionName, err)
 			}
 
-			if imageCount := len(images); (5 - imageCount) >= desiredImageCapacity {
+			if imageCount := len(images); (quota - imageCount) >= desiredImageCapacity {
 				if *verbose {
 					fmt.Printf("Region %v is under quota. (Images: %v, Quota: %v)\n", regionName, imageCount, quota)
 				}
 			} else {
-				numOfImagesToDelete := desiredImageCapacity - (5 - imageCount)
+				numOfImagesToDelete := desiredImageCapacity - (quota - imageCount)
 
 				arm64Images, legacyx86Images, x86Images := filterImages(images)
 

--- a/cleangoldenami/main.go
+++ b/cleangoldenami/main.go
@@ -21,6 +21,8 @@ const (
 	timeLayout  = "2006-01-02T15:04:05.000Z"
 	// desiredImageCapacity is the number of free "image slots" desired in each region
 	desiredImageCapacity = 3
+	ArchitectureARM64    = ec2Types.ArchitectureValuesArm64
+	ArchitectureX86      = ec2Types.ArchitectureValuesX8664
 )
 
 func main() {
@@ -200,11 +202,11 @@ func filterImages(images []ec2Types.Image) ([]ec2Types.Image, []ec2Types.Image, 
 	var arm64Images, legacyx86Images, x86Images []ec2Types.Image
 	for _, image := range images {
 
-		if hasVersionTag(image, "rhel-arm64") && hasMatchingArchitecture(image, "arm64") {
+		if hasVersionTag(image, "rhel-arm64") && hasMatchingArchitecture(image, ArchitectureARM64) {
 			arm64Images = append(arm64Images, image)
-		} else if hasVersionTag(image, "legacy-x86_64") && hasMatchingArchitecture(image, "x86_64") {
+		} else if hasVersionTag(image, "legacy-x86_64") && hasMatchingArchitecture(image, ArchitectureX86) {
 			legacyx86Images = append(legacyx86Images, image)
-		} else if hasVersionTag(image, "rhel-x86_64") && hasMatchingArchitecture(image, "x86_64") {
+		} else if hasVersionTag(image, "rhel-x86_64") && hasMatchingArchitecture(image, ArchitectureX86) {
 			x86Images = append(x86Images, image)
 		}
 	}

--- a/cleangoldenami/main.go
+++ b/cleangoldenami/main.go
@@ -96,17 +96,23 @@ func main() {
 							x86Images = append(x86Images[:imageToDeleteIndex], x86Images[imageToDeleteIndex+1:]...)
 						}
 					}
+					if !*dryRun {
+						fmt.Printf("Region %v image capacity is currently at %v out of %v:\n", regionName, len(images), quota)
+					} else {
+						fmt.Printf("Region %v image capacity is currently at %v out of %v - would delete the following AMIs:\n", regionName, len(images), quota)
+					}
 					for _, image := range imagesToDelete {
-						for i, t := range image.Tags {
+						for _, t := range image.Tags {
 							if *t.Key == "version" {
 								if !*dryRun {
 									err = deregisterImage(ec2Client, image)
 									if err != nil {
-										fmt.Printf("error deregistering image %v (%v) in region %v: %v\n", *image.ImageId, *image.Tags[i].Value, regionName, err)
+										fmt.Printf("  - error deregistering image %v (%v): %v\n", *image.ImageId, *t.Value, err)
+									} else {
+										fmt.Printf("  - successfully deregistered image %v (%v)\n", *image.ImageId, *t.Value)
 									}
-									fmt.Printf("successfully deregistered image %v (%v) in region %v\n", *image.ImageId, *image.Tags[i].Value, regionName)
 								} else {
-									fmt.Printf("Region %v is at quota (%v) - would delete %v (%v)\n", regionName, quota, *image.ImageId, *image.Tags[i].Value)
+									fmt.Printf("  - %v (%v)\n", *image.ImageId, *t.Value)
 								}
 								break
 							}

--- a/cleangoldenami/main.go
+++ b/cleangoldenami/main.go
@@ -105,15 +105,23 @@ func main() {
 				}
 				if *dryRun {
 					for _, image := range imagesToDelete {
-						fmt.Printf("Region %v is at quota (%v) - would delete %v (%v)\n", regionName, quota, *image.ImageId, *image.Tags[1].Value)
+						for i, t := range image.Tags {
+							if *t.Key == "version" {
+								fmt.Printf("Region %v is at quota (%v) - would delete %v (%v)\n", regionName, quota, *image.ImageId, *image.Tags[i].Value)
+							}
+						}
 					}
 				} else {
 					for _, image := range imagesToDelete {
-						err = deregisterImage(ec2Client, image)
-						if err != nil {
-							fmt.Printf("error deregistering image %v (%v) in region %v: %v", *image.ImageId, *image.Tags[0].Value, regionName, err)
+						for i, t := range image.Tags {
+							if *t.Key == "version" {
+								err = deregisterImage(ec2Client, image)
+								if err != nil {
+									fmt.Printf("error deregistering image %v (%v) in region %v: %v", *image.ImageId, *image.Tags[i].Value, regionName, err)
+								}
+								fmt.Printf("successfully deregistered image %v (%v) in region %v", *image.ImageId, *image.Tags[i].Value, regionName)
+							}
 						}
-						fmt.Printf("successfully deregistered image %v (%v) in region %v", *image.ImageId, *image.Tags[0].Value, regionName)
 					}
 				}
 			}

--- a/cleangoldenami/main.go
+++ b/cleangoldenami/main.go
@@ -117,9 +117,9 @@ func main() {
 							if *t.Key == "version" {
 								err = deregisterImage(ec2Client, image)
 								if err != nil {
-									fmt.Printf("error deregistering image %v (%v) in region %v: %v", *image.ImageId, *image.Tags[i].Value, regionName, err)
+									fmt.Printf("error deregistering image %v (%v) in region %v: %v\n", *image.ImageId, *image.Tags[i].Value, regionName, err)
 								}
-								fmt.Printf("successfully deregistered image %v (%v) in region %v", *image.ImageId, *image.Tags[i].Value, regionName)
+								fmt.Printf("successfully deregistered image %v (%v) in region %v\n", *image.ImageId, *image.Tags[i].Value, regionName)
 							}
 						}
 					}

--- a/cleangoldenami/main.go
+++ b/cleangoldenami/main.go
@@ -16,10 +16,10 @@ import (
 )
 
 const (
-	serviceCode          = "ec2"
-	quotaCode            = "L-0E3CBAB9"
-	timeLayout           = "2006-01-02T15:04:05.000Z"
-    // desiredImageCapacity is the number of free "image slots" desired in each region
+	serviceCode = "ec2"
+	quotaCode   = "L-0E3CBAB9"
+	timeLayout  = "2006-01-02T15:04:05.000Z"
+	// desiredImageCapacity is the number of free "image slots" desired in each region
 	desiredImageCapacity = 3
 )
 
@@ -104,23 +104,17 @@ func main() {
 						}
 					}
 				}
-				if *dryRun {
-					for _, image := range imagesToDelete {
-						for i, t := range image.Tags {
-							if *t.Key == "version" {
-								fmt.Printf("Region %v is at quota (%v) - would delete %v (%v)\n", regionName, quota, *image.ImageId, *image.Tags[i].Value)
-							}
-						}
-					}
-				} else {
-					for _, image := range imagesToDelete {
-						for i, t := range image.Tags {
-							if *t.Key == "version" {
+				for _, image := range imagesToDelete {
+					for i, t := range image.Tags {
+						if *t.Key == "version" {
+							if !*dryRun {
 								err = deregisterImage(ec2Client, image)
 								if err != nil {
 									fmt.Printf("error deregistering image %v (%v) in region %v: %v\n", *image.ImageId, *image.Tags[i].Value, regionName, err)
 								}
 								fmt.Printf("successfully deregistered image %v (%v) in region %v\n", *image.ImageId, *image.Tags[i].Value, regionName)
+							} else {
+								fmt.Printf("Region %v is at quota (%v) - would delete %v (%v)\n", regionName, quota, *image.ImageId, *image.Tags[i].Value)
 							}
 						}
 					}


### PR DESCRIPTION
<!-- Type of change
- Enhancement/Feature
-->

## What does this PR do? / Related Issues / Jira
Cleanup script makes sure to delete the oldest image of each type per region, not just the oldest image


## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have tested the functionality against gcp / aws, it doesn't cause any regression
- [x] I have added execution results to the PR's readme

## Reviewer's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] (This needs to be done after technical review) I've run the branch on my local, verified that the functionality is ok

## How to test this PR locally / Special Instructions

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Logs
```
 ./cleangoldenami --dry-run --verbose                                                                                                                                                                                                                                                                                         
 
Region us-east-1 is under quota. (Images: 15, Quota: 20)
Region ca-central-1 image capacity is currently at 18 out of 20 - would delete the following AMIs:
  - ami-085e5999c054f7443 (legacy-x86_64)
Region us-east-2 image capacity is currently at 20 out of 20 - would delete the following AMIs:
  - ami-06c3c5a8d32a87309 (legacy-x86_64)
  - ami-0241f2d4397f1cade (legacy-x86_64)
  - ami-01187490fcef7e973 (legacy-x86_64)
Region us-west-1 is under quota. (Images: 17, Quota: 20)
Region us-west-2 image capacity is currently at 20 out of 20 - would delete the following AMIs:
  - ami-0f3545f36033bd149 (legacy-x86_64)
  - ami-092d4784c0ed8dd7b (legacy-x86_64)
  - ami-0dc8384bb52397ee1 (legacy-x86_64)
Region eu-west-3 image capacity is currently at 20 out of 20 - would delete the following AMIs:
  - ami-0338ef435387e56f5 (legacy-x86_64)
  - ami-0ce34bc8ee9c5d0a5 (legacy-x86_64)
  - ami-0ab155e4e470cf8ba (legacy-x86_64)
Region eu-central-2 is under quota. (Images: 15, Quota: 20)
Region eu-south-2 is under quota. (Images: 13, Quota: 20)
Region eu-central-1 image capacity is currently at 10 out of 10 - would delete the following AMIs:
  - ami-04210135cdf44ea1c (legacy-x86_64)
  - ami-0d4c0955ff21d17f8 (legacy-x86_64)
  - ami-01fb645bfcd175ae3 (legacy-x86_64)
Region eu-west-2 image capacity is currently at 20 out of 20 - would delete the following AMIs:
  - ami-066d04a95ec5d05ec (legacy-x86_64)
  - ami-0a43c5ee82fcafc7e (legacy-x86_64)
  - ami-005ba6607acac7b3e (legacy-x86_64)
Region eu-west-1 image capacity is currently at 19 out of 20 - would delete the following AMIs:
  - ami-0d50fc23a64d30ce3 (legacy-x86_64)
  - ami-06e3bcae2dd1094b3 (legacy-x86_64)
Region eu-south-1 image capacity is currently at 18 out of 20 - would delete the following AMIs:
  - ami-0ec65dd668bb57b13 (legacy-x86_64)
Region eu-north-1 is under quota. (Images: 17, Quota: 20)
Region sa-east-1 image capacity is currently at 18 out of 20 - would delete the following AMIs:
  - ami-03bc0c48d7b1be18f (legacy-x86_64)
Region ap-northeast-3 image capacity is currently at 20 out of 20 - would delete the following AMIs:
  - ami-06fef0e3d72471d95 (legacy-x86_64)
  - ami-0c353b4b3fd722315 (legacy-x86_64)
  - ami-04c266b7da153547d (legacy-x86_64)
Region me-south-1 image capacity is currently at 20 out of 20 - would delete the following AMIs:
  - ami-04b01514ae0d9cb02 (legacy-x86_64)
  - ami-0470552c96f51f420 (legacy-x86_64)
  - ami-0194a03c002b56920 (legacy-x86_64)
Region ap-northeast-1 image capacity is currently at 20 out of 20 - would delete the following AMIs:
  - ami-06781703396c03861 (legacy-x86_64)
  - ami-0ae96a58772eb3fee (legacy-x86_64)
  - ami-0714a0f5da8f7233d (legacy-x86_64)
Region ap-southeast-4 is under quota. (Images: 14, Quota: 20)
Region ap-southeast-2 image capacity is currently at 19 out of 20 - would delete the following AMIs:
  - ami-011e0e2b03dedc185 (legacy-x86_64)
  - ami-02ffafb015ea5d2b6 (legacy-x86_64)
Region ap-northeast-2 image capacity is currently at 20 out of 20 - would delete the following AMIs:
  - ami-0a4778bbd67dce74e (legacy-x86_64)
  - ami-04af82fd7ade74d0c (legacy-x86_64)
  - ami-0da715520e52a5148 (legacy-x86_64)
Region ap-east-1 image capacity is currently at 20 out of 20 - would delete the following AMIs:
  - ami-0228bc3276f2577ac (legacy-x86_64)
  - ami-05c504972a83bb707 (legacy-x86_64)
  - ami-0d12284e21cac6d77 (legacy-x86_64)
Region me-central-1 is under quota. (Images: 14, Quota: 20)
Region af-south-1 image capacity is currently at 19 out of 20 - would delete the following AMIs:
  - ami-0d839f7a2ec1fb21a (legacy-x86_64)
  - ami-058366609e22d236c (legacy-x86_64)
Region ap-south-1 image capacity is currently at 20 out of 20 - would delete the following AMIs:
  - ami-07e6ef6f51e4b755a (legacy-x86_64)
  - ami-09ac10928e4613eb8 (legacy-x86_64)
  - ami-06ad0daa185ab5cb0 (legacy-x86_64)
Region ap-southeast-1 image capacity is currently at 20 out of 20 - would delete the following AMIs:
  - ami-0b934e5759760c619 (legacy-x86_64)
  - ami-0268d9c47dd43e6bd (legacy-x86_64)
  - ami-03a9fb3956e5eaa85 (legacy-x86_64)
Region ap-south-2 is under quota. (Images: 14, Quota: 20)
Region ap-southeast-3 image capacity is currently at 19 out of 20 - would delete the following AMIs:
  - ami-0c10bbee950a03d44 (legacy-x86_64)
  - ami-0432b0929298da020 (legacy-x86_64)
Done!

```

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
