### PR TITLE
OSD-22892 (Part 3): CurlJSONProbe Improvements

### DIFF
--- a/pkg/helpers/helpers.go
+++ b/pkg/helpers/helpers.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math/rand"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -215,4 +216,31 @@ func CutBetween(s string, startingToken string, endingToken string) string {
 		return ""
 	}
 	return matches[1]
+}
+
+// DurationToBareSeconds tries to parse a given string as a duration (e.g., "1m30s") and return the
+// total floating-point number of seconds in the duration. Failing that, it tries to return the left-
+// most number in the given string. Failing that (or given an empty string, NaN, or infinity), it
+// returns 0
+func DurationToBareSeconds(possibleDurationStr string) float64 {
+	// Return 0 for empty strings
+	if strings.TrimSpace(possibleDurationStr) == "" {
+		return 0
+	}
+
+	// Try to parse it as a time.Duration
+	if parsedDuration, err := time.ParseDuration(possibleDurationStr); err == nil {
+		// Success! So just return a floating point number of seconds
+		return parsedDuration.Seconds()
+	}
+
+	// Try to just pull out any number
+	reFloat := regexp.MustCompile(`-?\d+(\.\d*)?`)
+	if reFloat.MatchString(possibleDurationStr) {
+		f, _ := strconv.ParseFloat(reFloat.FindString(possibleDurationStr), 64)
+		return f
+	}
+
+	// possibleDurationStr looks nothing like a duration: fall back to 0
+	return 0
 }

--- a/pkg/helpers/helpers_test.go
+++ b/pkg/helpers/helpers_test.go
@@ -628,3 +628,74 @@ func TestRemoveTimestamps(t *testing.T) {
 		})
 	}
 }
+
+func TestDurationToBareSeconds(t *testing.T) {
+	tests := []struct {
+		name                string
+		possibleDurationStr string
+		want                float64
+	}{
+		{
+			name:                "simple duration",
+			possibleDurationStr: "3s",
+			want:                3,
+		},
+		{
+			name:                "compound duration",
+			possibleDurationStr: "1m3s",
+			want:                63,
+		},
+		{
+			name:                "bare integer",
+			possibleDurationStr: "7",
+			want:                7,
+		},
+		{
+			name:                "bare float",
+			possibleDurationStr: "1.11",
+			want:                1.11,
+		},
+		{
+			name:                "noisy number",
+			possibleDurationStr: "foo1.23bar",
+			want:                1.23,
+		},
+		{
+			name:                "no numbers",
+			possibleDurationStr: "foobar",
+			want:                0,
+		},
+		{
+			name:                "empty string",
+			possibleDurationStr: "",
+			want:                0,
+		},
+		{
+			name:                "negative unit",
+			possibleDurationStr: "-1m",
+			want:                -60.0,
+		},
+		{
+			name:                "negative float",
+			possibleDurationStr: "-3.33",
+			want:                -3.33,
+		},
+		{
+			name:                "nan",
+			possibleDurationStr: "NaN",
+			want:                0,
+		},
+		{
+			name:                "infinity",
+			possibleDurationStr: "Inf",
+			want:                0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := DurationToBareSeconds(tt.possibleDurationStr); got != tt.want {
+				t.Errorf("DurationToBareSeconds() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/probes/curl_json/curl_json.go
+++ b/pkg/probes/curl_json/curl_json.go
@@ -104,12 +104,14 @@ func (prb CurlJSONProbe) GetExpandedUserData(userDataVariables map[string]string
 	}
 
 	// Also for compatibility reasons, we map the NOTLS variable to curl's "insecure" flag
-	noTLS, err := strconv.ParseBool(userDataVariables["NOTLS"])
-	if err != nil {
-		return "", fmt.Errorf("invalid userdata variable NOTLS: %w", err)
-	}
-	if noTLS {
-		userDataVariables["CURLOPT"] += " -k "
+	if userDataVariables["NOTLS"] != "" {
+		noTLS, err := strconv.ParseBool(userDataVariables["NOTLS"])
+		if err != nil {
+			return "", fmt.Errorf("invalid userdata variable NOTLS: %w", err)
+		}
+		if noTLS {
+			userDataVariables["CURLOPT"] += " -k "
+		}
 	}
 
 	// Expand template

--- a/pkg/probes/curl_json/curl_json_test.go
+++ b/pkg/probes/curl_json/curl_json_test.go
@@ -69,6 +69,27 @@ func TestCurlJSONProbe_GetExpandedUserData(t *testing.T) {
 			wantRegex: `#cloud-config[\s\S]* -k [\s\S]*http:\/\/example.com:80 https:\/\/example.org:443`,
 		},
 		{
+			name: "tlsDisabled URLs provided",
+			userDataVariables: map[string]string{
+				"TIMEOUT":          "1",
+				"DELAY":            "2",
+				"URLS":             "http://example.com:80 https://example.org:443",
+				"TLSDISABLED_URLS": "https://example.net:443",
+			},
+			wantRegex: `#cloud-config[\s\S]*https:\/\/example.org:443[\s\S]*--next -k[\s\S]*https:\/\/example.net:443`,
+		},
+		{
+			name: "NOTLS and tlsDisabled URLs provided",
+			userDataVariables: map[string]string{
+				"TIMEOUT":          "1",
+				"DELAY":            "2",
+				"NOTLS":            "True",
+				"URLS":             "http://example.com:80 https://example.org:443",
+				"TLSDISABLED_URLS": "https://example.net:443",
+			},
+			wantRegex: `#cloud-config[\s\S]* -k [\s\S]*http:\/\/example.com:80 https:\/\/example.org:443 https:\/\/example.net:443`,
+		},
+		{
 			name:                      "missing variables required by directive",
 			userDataVariables:         map[string]string{},
 			wantErr:                   true,

--- a/pkg/probes/curl_json/curl_json_test.go
+++ b/pkg/probes/curl_json/curl_json_test.go
@@ -1,6 +1,7 @@
 package curl_json
 
 import (
+	_ "embed"
 	"regexp"
 	"strings"
 	"testing"
@@ -53,13 +54,19 @@ func TestCurlJSONProbe_GetExpandedUserData(t *testing.T) {
 				"TIMEOUT": "1",
 				"DELAY":   "2",
 				"URLS":    "http://example.com:80 https://example.org:443",
-				"CACERT": `write_files:
-- path: /proxy.pem
-  permissions: '0755'
-  encoding: b64
-  content: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUNiakNDQWZPZ0F3SUJBZ0lRWXZZeWJPWEU0MmhjRzJMZG5DNmRsVEFLQmdncWhrak9QUVFEQXpCNE1Rc3cKQ1FZRFZRUUdFd0pGVXpFUk1BOEdBMVVFQ2d3SVJrNU5WQzFTUTAweERqQU1CZ05WQkFzTUJVTmxjbVZ6TVJndwpGZ1lEVlFSaERBOVdRVlJGVXkxUk1qZ3lOakF3TkVveExEQXFCZ05WQkFNTUkwRkRJRkpCU1ZvZ1JrNU5WQzFTClEwMGdVMFZTVmtsRVQxSkZVeUJUUlVkVlVrOVRNQjRYRFRFNE1USXlNREE1TXpjek0xb1hEVFF6TVRJeU1EQTUKTXpjek0xb3dlREVMTUFrR0ExVUVCaE1DUlZNeEVUQVBCZ05WQkFvTUNFWk9UVlF0VWtOTk1RNHdEQVlEVlFRTApEQVZEWlhKbGN6RVlNQllHQTFVRVlRd1BWa0ZVUlZNdFVUSTRNall3TURSS01Td3dLZ1lEVlFRRERDTkJReUJTClFVbGFJRVpPVFZRdFVrTk5JRk5GVWxaSlJFOVNSVk1nVTBWSFZWSlBVekIyTUJBR0J5cUdTTTQ5QWdFR0JTdUIKQkFBaUEySUFCUGE2VjFQSXlxdmZOa3BTSWVTWDBvTm5udkJsVWRCZWg4ZEhzVm55VjBlYkFBS1RSQmRwMjBMSApzYkk2R0E2MFhZeXpabDJoTlBrMkxFbmI4MGI4czBScFJCTm0vZGZGL2E4MlRjNERUUWR4ejY5cUJkS2lRMW9LClVtOEJBMDZPaTZOQ01FQXdEd1lEVlIwVEFRSC9CQVV3QXdFQi96QU9CZ05WSFE4QkFmOEVCQU1DQVFZd0hRWUQKVlIwT0JCWUVGQUc1TCsrL0VZWmc4ay9RUVc2cmN4L24wbTVKTUFvR0NDcUdTTTQ5QkFNREEya0FNR1lDTVFDdQpTdU1yUU1OMEVmS1ZyUllqM2s0TUd1WmRwU1JlYTBSNy9EamlUOHVjUlJjUlRCUW5KbFU1ZFVvRHpCT1FuNUlDCk1RRDZTbXhnaUhQejdyaVlZcW5PSzhMWmlxWndNUjJ2c0pSTTYwL0c0OUh6WXFjOC81TXVCMXhKQVdkcEVnSnkKditjPQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==`,
+				"CACERT":  "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUNiakNDQWZPZ0F3SUJBZ0lRWXZZeWJPWEU0MmhjRzJMZG5DNmRsVEFLQmdncWhrak9QUVFEQXpCNE1Rc3cKQ1FZRFZRUUdFd0pGVXpFUk1BOEdBMVVFQ2d3SVJrNU5WQzFTUTAweERqQU1CZ05WQkFzTUJVTmxjbVZ6TVJndwpGZ1lEVlFSaERBOVdRVlJGVXkxUk1qZ3lOakF3TkVveExEQXFCZ05WQkFNTUkwRkRJRkpCU1ZvZ1JrNU5WQzFTClEwMGdVMFZTVmtsRVQxSkZVeUJUUlVkVlVrOVRNQjRYRFRFNE1USXlNREE1TXpjek0xb1hEVFF6TVRJeU1EQTUKTXpjek0xb3dlREVMTUFrR0ExVUVCaE1DUlZNeEVUQVBCZ05WQkFvTUNFWk9UVlF0VWtOTk1RNHdEQVlEVlFRTApEQVZEWlhKbGN6RVlNQllHQTFVRVlRd1BWa0ZVUlZNdFVUSTRNall3TURSS01Td3dLZ1lEVlFRRERDTkJReUJTClFVbGFJRVpPVFZRdFVrTk5JRk5GVWxaSlJFOVNSVk1nVTBWSFZWSlBVekIyTUJBR0J5cUdTTTQ5QWdFR0JTdUIKQkFBaUEySUFCUGE2VjFQSXlxdmZOa3BTSWVTWDBvTm5udkJsVWRCZWg4ZEhzVm55VjBlYkFBS1RSQmRwMjBMSApzYkk2R0E2MFhZeXpabDJoTlBrMkxFbmI4MGI4czBScFJCTm0vZGZGL2E4MlRjNERUUWR4ejY5cUJkS2lRMW9LClVtOEJBMDZPaTZOQ01FQXdEd1lEVlIwVEFRSC9CQVV3QXdFQi96QU9CZ05WSFE4QkFmOEVCQU1DQVFZd0hRWUQKVlIwT0JCWUVGQUc1TCsrL0VZWmc4ay9RUVc2cmN4L24wbTVKTUFvR0NDcUdTTTQ5QkFNREEya0FNR1lDTVFDdQpTdU1yUU1OMEVmS1ZyUllqM2s0TUd1WmRwU1JlYTBSNy9EamlUOHVjUlJjUlRCUW5KbFU1ZFVvRHpCT1FuNUlDCk1RRDZTbXhnaUhQejdyaVlZcW5PSzhMWmlxWndNUjJ2c0pSTTYwL0c0OUh6WXFjOC81TXVCMXhKQVdkcEVnSnkKditjPQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==",
 			},
-			wantRegex: `#cloud-config[\s\S]*proxy.pem[\s\S]*LS0tLS1CRUd\w*Cg==\n[\s\S]*https://example.org:443`,
+			wantRegex: `#cloud-config[\s\S]*proxy.pem[\s\S]*encoding: b64[\s\S]*LS0tLS1CRUd\w*Cg==\n[\s\S]*https://example.org:443`,
+		},
+		{
+			name: "set NOTLS",
+			userDataVariables: map[string]string{
+				"TIMEOUT": "1",
+				"DELAY":   "2",
+				"URLS":    "http://example.com:80 https://example.org:443",
+				"NOTLS":   "True",
+			},
+			wantRegex: `#cloud-config[\s\S]* -k [\s\S]*http:\/\/example.com:80 https:\/\/example.org:443`,
 		},
 		{
 			name:                      "missing variables required by directive",
@@ -74,6 +81,24 @@ func TestCurlJSONProbe_GetExpandedUserData(t *testing.T) {
 				"DELAY":          "2",
 				"URLS":           "http://example.com:80 https://example.org:443",
 				"USERDATA_BEGIN": "foobar",
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid DELAY",
+			userDataVariables: map[string]string{
+				"TIMEOUT": "1",
+				"DELAY":   "-2",
+				"URLS":    "http://example.com:80 https://example.org:443",
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid TIMEOUT",
+			userDataVariables: map[string]string{
+				"TIMEOUT": "-1",
+				"DELAY":   "2",
+				"URLS":    "http://example.com:80 https://example.org:443",
 			},
 			wantErr: true,
 		},
@@ -263,6 +288,69 @@ func TestCurlJSONProbe_GetMachineImageID(t *testing.T) {
 				if len(reWant.FindString(got)) < 1 {
 					t.Errorf("CurlJSONProbe.GetMachineImageID() output does not match regex `%s`, content=%v", tt.wantRegex, got)
 				}
+			}
+		})
+	}
+}
+
+// Test_normalizeSaneNonzeroDuration tests this probe's duration string normalization
+// and sanity checking function. This test assumes fmtStr = "%.2f"
+func Test_normalizeSaneNonzeroDuration(t *testing.T) {
+	tests := []struct {
+		name                string
+		possibleDurationStr string
+		want                string
+		wantErr             bool
+	}{
+		{
+			name:                "integer with unit",
+			possibleDurationStr: "3s",
+			want:                "3.00",
+			wantErr:             false,
+		},
+		{
+			name:                "float with unit",
+			possibleDurationStr: "1.2s",
+			want:                "1.20",
+			wantErr:             false,
+		},
+		{
+			name:                "bare integer",
+			possibleDurationStr: "7",
+			want:                "7.00",
+			wantErr:             false,
+		},
+		{
+			name:                "bare float",
+			possibleDurationStr: "6.5",
+			want:                "6.50",
+			wantErr:             false,
+		},
+		{
+			name:                "too large",
+			possibleDurationStr: "4h",
+			wantErr:             true,
+		},
+		{
+			name:                "negative integer",
+			possibleDurationStr: "-3",
+			wantErr:             true,
+		},
+		{
+			name:                "negative with unit",
+			possibleDurationStr: "-1m",
+			wantErr:             true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := normalizeSaneNonzeroDuration(tt.possibleDurationStr, "%.2f")
+			if (err != nil) != tt.wantErr {
+				t.Errorf("normalizeSaneNonzeroDuration() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("normalizeSaneNonzeroDuration() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/probes/curl_json/userdata-template.yaml
+++ b/pkg/probes/curl_json/userdata-template.yaml
@@ -1,6 +1,6 @@
 #cloud-config
 # network-verifier-required-variables=TIMEOUT,DELAY,URLS
-${CACERT}
+${CACERT_RENDERED}
 runcmd:
   - systemctl mask --now serial-getty@ttyS0.service
   - dmesg -D

--- a/pkg/probes/curl_json/userdata-template.yaml
+++ b/pkg/probes/curl_json/userdata-template.yaml
@@ -6,7 +6,7 @@ runcmd:
   - dmesg -D
   - echo "${USERDATA_BEGIN}" >/dev/ttyS0
   - export http_proxy=${HTTP_PROXY} https_proxy=${HTTPS_PROXY}
-  - curl --retry 3 --retry-connrefused -t B -Z -s -I -m ${TIMEOUT} -w "%{stderr}${LINE_PREFIX}%{json}\n" ${CURLOPT} ${URLS} --proto =http,https,telnet 2>/dev/ttyS0
+  - curl --retry 3 --retry-connrefused -t B -Z -s -I -m ${TIMEOUT} -w "%{stderr}${LINE_PREFIX}%{json}\n" ${CURLOPT} ${URLS} --proto =http,https,telnet ${TLSDISABLED_URLS_RENDERED} 2>/dev/ttyS0
   - echo "${USERDATA_END}" >/dev/ttyS0
 power_state:
   delay: ${DELAY}


### PR DESCRIPTION
## What does this PR do? / Related Issues / Jira
This PR is composed of commits cherry-picked from my larger [OSD-22892](https://issues.redhat.com/browse/OSD-22892) branch for the sake of readability.

These commits improve CurlJSONProbe's ability to validate input variables and "render" special userdata template variables. For example, the verifier's existing critical path sets duration-as-a-string values  (e.g., "1m3s" for 63 seconds) for the the `TIMEOUT` and `DELAY` userdata variables. Curl's `--max-time ${TIMEOUT}` flag doesn't accept such non-numeric values, so we've added a function called `normalizeSaneNonzeroDuration()` that converts durations-as-strings into floating-point quantities of seconds, does some sanity checking (i.e., 0 < `TIMEOUT` < 3hrs), and returns a curl-safe float-as-a-string (or, in the case of `DELAY`, a cloud-init-safe int-as-a-string). In a similar vein, we also now translate the `NOTLS` and `CACERT` variables into their curl-safe equivalents.

This PR also lays the groundwork for "tlsDisabled" URL support (i.e., HTTPS URLs that we'd like curl to not verify the TLS cert for), which was not included in the original experimental curl probe. We do this by using curl's "parser reset" flag ("--next" or "-:") to do this, but this has the unfortunate side effect of forcing us to re-pass most curl flags (except global flags and those irrelevant to HTTPS).

This PR intentionally does *not* cover integration of this new code into the verifier's critical path. That integration is covered in #246. As such, there isn't much to execute for this PR beyond the included unit tests. **When reviewing this PR, please focus on code style/structure.**

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have tested the functionality against gcp / aws, it doesn't cause any regression
- ~~[ ] I have added execution results to the PR's readme~~