### PR TITLE
Remove deprecated 'securityGroupId' property from createEC2InstanceInput

### DIFF
--- a/cmd/egress/cmd.go
+++ b/cmd/egress/cmd.go
@@ -34,7 +34,6 @@ type egressConfig struct {
 	vpcSubnetID                string
 	cloudImageID               string
 	instanceType               string
-	securityGroupId            string // Deprecated: prefer securityGroupIDs
 	securityGroupIDs           []string
 	cloudTags                  map[string]string
 	debug                      bool
@@ -142,7 +141,6 @@ are set correctly before execution.
 				//Setup AWS Specific Configs
 				vei.AWS = verifier.AwsEgressConfig{
 					KmsKeyID:         config.kmsKeyID,
-					SecurityGroupId:  config.securityGroupId,
 					SecurityGroupIDs: config.securityGroupIDs,
 				}
 
@@ -239,7 +237,6 @@ are set correctly before execution.
 	validateEgressCmd.Flags().StringVar(&config.vpcSubnetID, "subnet-id", "", "source subnet ID")
 	validateEgressCmd.Flags().StringVar(&config.cloudImageID, "image-id", "", "(optional) cloud image for the compute instance")
 	validateEgressCmd.Flags().StringVar(&config.instanceType, "instance-type", "t3.micro", "(optional) compute instance type")
-	validateEgressCmd.Flags().StringVar(&config.securityGroupId, "security-group-id", "", "(deprecated in favor of --security-group-ids)")
 	validateEgressCmd.Flags().StringSliceVar(&config.securityGroupIDs, "security-group-ids", []string{}, "(optional) comma-separated list of sec. group IDs to attach to the created EC2 instance. If absent, one will be created")
 	validateEgressCmd.Flags().StringVar(&config.region, "region", "", fmt.Sprintf("(optional) compute instance region. If absent, environment var %[1]v = %[2]v and %[3]v = %[4]v will be used", awsRegionEnvVarStr, awsRegionDefault, gcpRegionEnvVarStr, gcpRegionDefault))
 	validateEgressCmd.Flags().StringToStringVar(&config.cloudTags, "cloud-tags", map[string]string{}, "(optional) comma-seperated list of tags to assign to cloud resources e.g. --cloud-tags key1=value1,key2=value2")
@@ -261,7 +258,5 @@ are set correctly before execution.
 		validateEgressCmd.PrintErr(err)
 	}
 
-	//Mark securityGroupId and securityGroupsIDs flags as mutually exclusive (one or the other should be passed, not both).
-	validateEgressCmd.MarkFlagsMutuallyExclusive("security-group-id", "security-group-ids")
 	return validateEgressCmd
 }

--- a/pkg/verifier/aws/aws_verifier.go
+++ b/pkg/verifier/aws/aws_verifier.go
@@ -155,7 +155,6 @@ type createEC2InstanceInput struct {
 	SubnetID            string
 	userdata            string
 	KmsKeyID            string
-	securityGroupId     string // Deprecated: prefer securityGroupIDs
 	securityGroupIDs    []string
 	tempSecurityGroupID string
 	instanceCount       int32
@@ -179,12 +178,6 @@ func (a *AwsVerifier) createEC2Instance(input createEC2InstanceInput) (string, e
 	eniSpecification := ec2Types.InstanceNetworkInterfaceSpecification{
 		DeviceIndex: awsTools.Int32(0),
 		SubnetId:    awsTools.String(input.SubnetID),
-	}
-
-	// An empty string does not default to the default security group, and returns this error:
-	// error performing ec2:RunInstances: Value () for parameter groupId is invalid. The value cannot be empty
-	if input.securityGroupId != "" {
-		eniSpecification.Groups = append(eniSpecification.Groups, input.securityGroupId)
 	}
 
 	if len(input.securityGroupIDs) > 0 {

--- a/pkg/verifier/aws/entry_point.go
+++ b/pkg/verifier/aws/entry_point.go
@@ -173,7 +173,7 @@ func (a *AwsVerifier) ValidateEgress(vei verifier.ValidateEgressInput) *output.O
 	}
 
 	// If security group not given, create a temporary one
-	if vei.AWS.SecurityGroupId == "" && len(vei.AWS.SecurityGroupIDs) == 0 || vei.ForceTempSecurityGroup {
+	if len(vei.AWS.SecurityGroupIDs) == 0 || vei.ForceTempSecurityGroup {
 
 		createSecurityGroupOutput, err := a.CreateSecurityGroup(vei.Ctx, vei.Tags, "osd-network-verifier", vpcId)
 		if err != nil {
@@ -215,7 +215,6 @@ func (a *AwsVerifier) ValidateEgress(vei verifier.ValidateEgressInput) *output.O
 		ctx:                 vei.Ctx,
 		instanceType:        vei.InstanceType,
 		tags:                vei.Tags,
-		securityGroupId:     vei.AWS.SecurityGroupId,
 		securityGroupIDs:    vei.AWS.SecurityGroupIDs,
 		tempSecurityGroupID: vei.AWS.TempSecurityGroup,
 		keyPair:             vei.ImportKeyPair,

--- a/pkg/verifier/package_verifier.go
+++ b/pkg/verifier/package_verifier.go
@@ -40,7 +40,6 @@ type ValidateEgressInput struct {
 }
 type AwsEgressConfig struct {
 	KmsKeyID          string
-	SecurityGroupId   string // Deprecated: prefer securityGroupIDs
 	SecurityGroupIDs  []string
 	TempSecurityGroup string
 }


### PR DESCRIPTION
Removes deprecated `securityGroupId` property from `createEc2InstanceInput` struct.

Depends on PRs to the three known downstream consumers to stop using the field:
osdctl: https://github.com/openshift/osdctl/pull/592 (merged)
CAD: https://github.com/openshift/configuration-anomaly-detection/pull/300 (merged)
CS: No uses detected
