### PR TITLE
Standardize how we set defaults and clarify egressURL output

### DIFF
--- a/cmd/egress/cmd.go
+++ b/cmd/egress/cmd.go
@@ -241,7 +241,7 @@ are set correctly before execution.
 	validateEgressCmd.Flags().StringVar(&config.region, "region", "", fmt.Sprintf("(optional) compute instance region. If absent, environment var %[1]v = %[2]v and %[3]v = %[4]v will be used", awsRegionEnvVarStr, awsRegionDefault, gcpRegionEnvVarStr, gcpRegionDefault))
 	validateEgressCmd.Flags().StringToStringVar(&config.cloudTags, "cloud-tags", map[string]string{}, "(optional) comma-seperated list of tags to assign to cloud resources e.g. --cloud-tags key1=value1,key2=value2")
 	validateEgressCmd.Flags().BoolVar(&config.debug, "debug", false, "(optional) if true, enable additional debug-level logging")
-	validateEgressCmd.Flags().DurationVar(&config.timeout, "timeout", 2*time.Second, "(optional) timeout for individual egress verification requests")
+	validateEgressCmd.Flags().DurationVar(&config.timeout, "timeout", 5*time.Second, "(optional) timeout for individual egress verification requests")
 	validateEgressCmd.Flags().StringVar(&config.kmsKeyID, "kms-key-id", "", "(optional) ID of KMS key used to encrypt root volumes of compute instances. Defaults to cloud account default key")
 	validateEgressCmd.Flags().StringVar(&config.httpProxy, "http-proxy", "", "(optional) http-proxy to be used upon http requests being made by verifier, format: http://user:pass@x.x.x.x:8978")
 	validateEgressCmd.Flags().StringVar(&config.httpsProxy, "https-proxy", "", "(optional) https-proxy to be used upon https requests being made by verifier, format: https://user:pass@x.x.x.x:8978")

--- a/cmd/egress/cmd.go
+++ b/cmd/egress/cmd.go
@@ -234,14 +234,14 @@ are set correctly before execution.
 	}
 
 	validateEgressCmd.Flags().StringVar(&config.platformType, "platform", platformTypeDefault, fmt.Sprintf("(optional) infra platform type, which determines which endpoints to test. Either '%v', '%v', or '%v' (hypershift)", helpers.PlatformAWSClassic, helpers.PlatformGCPClassic, helpers.PlatformAWSHCP))
-	validateEgressCmd.Flags().StringVar(&config.vpcSubnetID, "subnet-id", "", "source subnet ID")
+	validateEgressCmd.Flags().StringVar(&config.vpcSubnetID, "subnet-id", "", "target subnet ID")
 	validateEgressCmd.Flags().StringVar(&config.cloudImageID, "image-id", "", "(optional) cloud image for the compute instance")
 	validateEgressCmd.Flags().StringVar(&config.instanceType, "instance-type", "t3.micro", "(optional) compute instance type")
 	validateEgressCmd.Flags().StringSliceVar(&config.securityGroupIDs, "security-group-ids", []string{}, "(optional) comma-separated list of sec. group IDs to attach to the created EC2 instance. If absent, one will be created")
 	validateEgressCmd.Flags().StringVar(&config.region, "region", "", fmt.Sprintf("(optional) compute instance region. If absent, environment var %[1]v = %[2]v and %[3]v = %[4]v will be used", awsRegionEnvVarStr, awsRegionDefault, gcpRegionEnvVarStr, gcpRegionDefault))
 	validateEgressCmd.Flags().StringToStringVar(&config.cloudTags, "cloud-tags", map[string]string{}, "(optional) comma-seperated list of tags to assign to cloud resources e.g. --cloud-tags key1=value1,key2=value2")
 	validateEgressCmd.Flags().BoolVar(&config.debug, "debug", false, "(optional) if true, enable additional debug-level logging")
-	validateEgressCmd.Flags().DurationVar(&config.timeout, "timeout", 5*time.Second, "(optional) timeout for individual egress verification requests")
+	validateEgressCmd.Flags().DurationVar(&config.timeout, "timeout", time.Duration(0), "(optional) timeout for individual egress verification requests")
 	validateEgressCmd.Flags().StringVar(&config.kmsKeyID, "kms-key-id", "", "(optional) ID of KMS key used to encrypt root volumes of compute instances. Defaults to cloud account default key")
 	validateEgressCmd.Flags().StringVar(&config.httpProxy, "http-proxy", "", "(optional) http-proxy to be used upon http requests being made by verifier, format: http://user:pass@x.x.x.x:8978")
 	validateEgressCmd.Flags().StringVar(&config.httpsProxy, "https-proxy", "", "(optional) https-proxy to be used upon https requests being made by verifier, format: https://user:pass@x.x.x.x:8978")

--- a/pkg/probes/curl/curl_json.go
+++ b/pkg/probes/curl/curl_json.go
@@ -48,6 +48,10 @@ func (clp Probe) GetMachineImageID(platformType string, cpuArch cpu.Architecture
 	if err != nil {
 		return "", err
 	}
+	if normalizedPlatformType == helpers.PlatformHostedCluster {
+		// HCP uses the same AMIs as Classic
+		normalizedPlatformType = helpers.PlatformAWS
+	}
 
 	// Normalize region key (GCP images are global/not region-scoped)
 	normalizedRegion := region

--- a/pkg/probes/curl/curl_json.go
+++ b/pkg/probes/curl/curl_json.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/openshift/osd-network-verifier/pkg/data/cpu"
 	handledErrors "github.com/openshift/osd-network-verifier/pkg/errors"
@@ -164,8 +165,11 @@ func (clp Probe) ParseProbeOutput(probeOutput string, outputDestination *output.
 	for _, probeResult := range probeResults {
 		outputDestination.AddDebugLogs(fmt.Sprintf("%+v\n", probeResult))
 		if !probeResult.IsSuccessfulConnection() {
+			// Replace "telnet" with "tcp" in output to prevent confusion over a probe
+			// implementation detail
+			url := strings.Replace(probeResult.URL, "telnet", "tcp", 1)
 			outputDestination.SetEgressFailures(
-				[]string{fmt.Sprintf("%s (%s)", probeResult.URL, probeResult.ErrorMsg)},
+				[]string{fmt.Sprintf("%s (%s)", url, probeResult.ErrorMsg)},
 			)
 		}
 	}

--- a/pkg/probes/curl/curl_json_test.go
+++ b/pkg/probes/curl/curl_json_test.go
@@ -239,6 +239,16 @@ func TestCurlJSONProbe_GetMachineImageID(t *testing.T) {
 			wantErr:   false,
 		},
 		{
+			name: "AWS HCP",
+			args: args{
+				platformType: helpers.PlatformAWSHCP,
+				cpuArch:      cpu.ArchX86,
+				region:       "us-east-1",
+			},
+			wantRegex: `ami-\w+`,
+			wantErr:   false,
+		},
+		{
 			name: "AWS ARM",
 			args: args{
 				platformType: helpers.PlatformAWSClassic,

--- a/pkg/probes/legacy/legacy.go
+++ b/pkg/probes/legacy/legacy.go
@@ -53,6 +53,10 @@ func (lgp Probe) GetMachineImageID(platformType string, cpuArch cpu.Architecture
 	if err != nil {
 		return "", err
 	}
+	if normalizedPlatformType == helpers.PlatformHostedCluster {
+		// HCP uses the same AMIs as Classic
+		normalizedPlatformType = helpers.PlatformAWS
+	}
 
 	// Access lookup table
 	imageID, keyExists := cloudMachineImageMap[normalizedPlatformType][cpuArch][region]

--- a/pkg/probes/legacy/legacy_test.go
+++ b/pkg/probes/legacy/legacy_test.go
@@ -57,6 +57,16 @@ func TestLegacyProbe_GetMachineImageID(t *testing.T) {
 			wantErr:   false,
 		},
 		{
+			name: "AWS HCP",
+			args: args{
+				platformType: helpers.PlatformAWSHCP,
+				cpuArch:      cpu.ArchX86,
+				region:       "us-east-1",
+			},
+			wantRegex: `ami-\w+`,
+			wantErr:   false,
+		},
+		{
 			name: "GCP must error",
 			args: args{
 				platformType: helpers.PlatformGCP,

--- a/pkg/verifier/aws/entry_point.go
+++ b/pkg/verifier/aws/entry_point.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"time"
 
 	awsTools "github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -14,6 +15,7 @@ import (
 	handledErrors "github.com/openshift/osd-network-verifier/pkg/errors"
 	"github.com/openshift/osd-network-verifier/pkg/helpers"
 	"github.com/openshift/osd-network-verifier/pkg/output"
+	"github.com/openshift/osd-network-verifier/pkg/probes/curl"
 	"github.com/openshift/osd-network-verifier/pkg/verifier"
 )
 
@@ -31,7 +33,27 @@ const (
 // - find unreachable endpoints & parse output, then terminate instance
 // - return `a.output` which stores the execution results
 func (a *AwsVerifier) ValidateEgress(vei verifier.ValidateEgressInput) *output.Output {
-	a.writeDebugLogs(vei.Ctx, fmt.Sprintf("Using configured timeout of %s for each egress request", vei.Timeout.String()))
+	// Validate cloud platform type and default to PlatformAWS if necessary
+	if vei.PlatformType == "" {
+		vei.PlatformType = helpers.PlatformAWS
+	}
+	normalizedPlatformType, err := helpers.GetPlatformType(vei.PlatformType)
+	if err != nil {
+		return a.Output.AddError(fmt.Errorf("cannot use platform type %s: %w", vei.PlatformType, err))
+	}
+	vei.PlatformType = normalizedPlatformType
+
+	// Default to curl.Probe if no Probe specified
+	if vei.Probe == nil {
+		vei.Probe = curl.Probe{}
+		a.writeDebugLogs(vei.Ctx, "defaulted to curl probe")
+	}
+
+	// Assume 5sec timeout if none specified
+	if vei.Timeout <= 0 {
+		vei.Timeout = time.Duration(5e9) // 5x10^9 nanoseconds = 5 seconds
+	}
+	a.writeDebugLogs(vei.Ctx, fmt.Sprintf("configured a %s timeout for each egress request", vei.Timeout))
 
 	// Set default instance type if none is found
 	if vei.InstanceType == "" {

--- a/pkg/verifier/aws/entry_point.go
+++ b/pkg/verifier/aws/entry_point.go
@@ -49,7 +49,7 @@ func (a *AwsVerifier) ValidateEgress(vei verifier.ValidateEgressInput) *output.O
 		a.writeDebugLogs(vei.Ctx, "defaulted to curl probe")
 	}
 
-	// Assume 5sec timeout if none specified
+	// Default to 5sec per-request timeout if none specified
 	if vei.Timeout <= 0 {
 		vei.Timeout = time.Duration(5e9) // 5x10^9 nanoseconds = 5 seconds
 	}

--- a/pkg/verifier/package_verifier.go
+++ b/pkg/verifier/package_verifier.go
@@ -25,6 +25,8 @@ type verifierService interface {
 }
 
 type ValidateEgressInput struct {
+	// Timeout sets the maximum duration an egress endpoint request can take before it aborts and
+	// is retried or marked as blocked
 	Timeout                                            time.Duration
 	Ctx                                                context.Context
 	SubnetID, CloudImageID, InstanceType, PlatformType string


### PR DESCRIPTION
<!-- Type of change
Please mark this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement/Feature
- Refactoring
- Tests
- Configuration
- Docs
-->

## What does this PR do?
This PR changes the way we're setting the default values of certain probe parameters (e.g., per-request timeout) such that users of the `osd-network-verifier` CLI will get an experience that's more consistent with consumers of the API (e.g., OCM). The only concrete change to defaults is the increase of the per-request timeout from 2s to 5s.

This PR also improves probe outputs by replacing "telnet" with "tcp" (since "telnet" is just an implementation detail and might confuse customers) and improves AMI selection with support for the HCP platform type.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have tested the functionality against ~~gcp~~ / aws, it doesn't cause any regression
- [x] I have added execution results to the PR's readme

## How to test this PR
Checkout this PR, run `make test build`, and then play around with `./osd-network-verifier` like you normally would. To test the specific behaviors changed by this PR, try specifying the HCP lists with `--platform=hostedcluster` or leaving off the `--probe` flag.

## Logs 

```
$ ./osd-network-verifier egress --profile=default --region=$AWS_REGION --subnet-id=$SUBNET --security-group-ids=$SECURITY_GROUP
Using region: eu-west-1
Created instance with ID: i-0d8fe7f1e2384d08e
Deleting instance with ID: i-0d8fe7f1e2384d08e
Summary:
printing out failures:
 - egressURL error: tcp://inputs1.osdsecuritylogs.splunkcloud.com:9997 (Failed to connect to inputs1.osdsecuritylogs.splunkcloud.com port 9997: Connection timed out)
 - egressURL error: tcp://inputs2.osdsecuritylogs.splunkcloud.com:9997 (Failed to connect to inputs2.osdsecuritylogs.splunkcloud.com port 9997: Connection timed out)
 - egressURL error: tcp://inputs4.osdsecuritylogs.splunkcloud.com:9997 (Failed to connect to inputs4.osdsecuritylogs.splunkcloud.com port 9997: Connection timed out)
 - egressURL error: tcp://inputs5.osdsecuritylogs.splunkcloud.com:9997 (Failed to connect to inputs5.osdsecuritylogs.splunkcloud.com port 9997: Connection timed out)
 - egressURL error: tcp://inputs6.osdsecuritylogs.splunkcloud.com:9997 (Failed to connect to inputs6.osdsecuritylogs.splunkcloud.com port 9997: Connection timed out)
 - egressURL error: tcp://inputs7.osdsecuritylogs.splunkcloud.com:9997 (Failed to connect to inputs7.osdsecuritylogs.splunkcloud.com port 9997: Connection timed out)
 - egressURL error: tcp://inputs8.osdsecuritylogs.splunkcloud.com:9997 (Failed to connect to inputs8.osdsecuritylogs.splunkcloud.com port 9997: Connection timed out)
 - egressURL error: tcp://inputs9.osdsecuritylogs.splunkcloud.com:9997 (Failed to connect to inputs9.osdsecuritylogs.splunkcloud.com port 9997: Connection timed out)
 - egressURL error: tcp://inputs10.osdsecuritylogs.splunkcloud.com:9997 (Failed to connect to inputs10.osdsecuritylogs.splunkcloud.com port 9997: Connection timed out)
 - egressURL error: tcp://inputs11.osdsecuritylogs.splunkcloud.com:9997 (Failed to connect to inputs11.osdsecuritylogs.splunkcloud.com port 9997: Connection timed out)
 - egressURL error: tcp://inputs12.osdsecuritylogs.splunkcloud.com:9997 (Failed to connect to inputs12.osdsecuritylogs.splunkcloud.com port 9997: Connection timed out)
 - egressURL error: tcp://inputs13.osdsecuritylogs.splunkcloud.com:9997 (Failed to connect to inputs13.osdsecuritylogs.splunkcloud.com port 9997: Connection timed out)
 - egressURL error: tcp://inputs14.osdsecuritylogs.splunkcloud.com:9997 (Failed to connect to inputs14.osdsecuritylogs.splunkcloud.com port 9997: Connection timed out)
 - egressURL error: tcp://inputs15.osdsecuritylogs.splunkcloud.com:9997 (Failed to connect to inputs15.osdsecuritylogs.splunkcloud.com port 9997: Connection timed out)
 - egressURL error: https://registry.redhat.io:443 (Operation timed out after 5221 milliseconds with 0 out of 0 bytes received)
 - egressURL error: https://api.openshift.com:443 (Operation timed out after 5218 milliseconds with 0 out of 0 bytes received)
 - egressURL error: https://http-inputs-osdsecuritylogs.splunkcloud.com:443 (Operation timed out after 5218 milliseconds with 0 out of 0 bytes received)

printing out exceptions preventing the verifier from running the specific test:
printing out errors faced during the execution:
Failure!
```
