### PR TITLE
Fetch url list from github first before falling back to local

### DIFF
--- a/cmd/egress/cmd.go
+++ b/cmd/egress/cmd.go
@@ -84,7 +84,7 @@ AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY (also AWS_SESSION_TOKEN for STS credent
 are set correctly before execution.
 
 # Verify that essential OpenShift domains are reachable from a given SUBNET_ID/SECURITY_GROUP association
-./osd-network-verifier egress --subnet-id ${SUBNET_ID} --security-group-id ${SECURITY_GROUP}`,
+./osd-network-verifier egress --subnet-id ${SUBNET_ID} --security-group-ids ${SECURITY_GROUP}`,
 		Run: func(cmd *cobra.Command, args []string) {
 			// OSD-20380 - remapping for backwards compatibility
 			platformType, err := helpers.GetPlatformType(config.platformType)
@@ -253,7 +253,7 @@ are set correctly before execution.
 	validateEgressCmd.Flags().StringVar(&config.terminateDebugInstance, "terminate-debug", "", "(optional) Takes the debug instance ID and terminates it")
 	validateEgressCmd.Flags().StringVar(&config.importKeyPair, "import-keypair", "", "(optional) Takes the path to your public key used to connect to Debug Instance. Automatically skips Termination")
 	validateEgressCmd.Flags().BoolVar(&config.ForceTempSecurityGroup, "force-temp-security-group", false, "(optional) Enforces creation of Temporary SG even if --security-group-ids flag is used")
-	validateEgressCmd.Flags().StringVar(&config.probeName, "probe", "CurlJSON", "(optional) select the probe to be used for egress testing. Either 'CurlJSON' (default) or 'Legacy'")
+	validateEgressCmd.Flags().StringVar(&config.probeName, "probe", "Curl", "(optional) select the probe to be used for egress testing. Either 'Curl' (default) or 'Legacy'")
 	if err := validateEgressCmd.MarkFlagRequired("subnet-id"); err != nil {
 		validateEgressCmd.PrintErr(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/openshift/osd-network-verifier
 
-go 1.20
+go 1.21
+
+toolchain go1.22.2
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.11.2
@@ -9,6 +11,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.24.0
 	github.com/aws/smithy-go v1.9.0
 	github.com/go-playground/validator v9.31.0+incompatible
+	github.com/google/go-github/v63 v63.0.0
 	github.com/openshift-online/ocm-sdk-go v0.1.224
 	github.com/spf13/cobra v1.8.0
 	go.uber.org/mock v0.4.0
@@ -32,6 +35,7 @@ require (
 	github.com/golang/glog v1.1.0 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
+	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.2.3 // indirect
 	github.com/googleapis/gax-go/v2 v2.7.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,7 @@ cloud.google.com/go/compute v1.19.1/go.mod h1:6ylj3a05WF8leseCdIf77NK0g1ey+nj5IK
 cloud.google.com/go/compute/metadata v0.2.3 h1:mg4jlk7mCAj6xXp9UJ4fjI9VUI5rubuGBW5aJ7UnBMY=
 cloud.google.com/go/compute/metadata v0.2.3/go.mod h1:VAV5nSsACxMJvgaAuX6Pk2AawlZn8kiOGuCv6gTkwuA=
 cloud.google.com/go/longrunning v0.4.1 h1:v+yFJOfKC3yZdY6ZUI933pIYdhyhV8S3NpWrXWmg7jM=
+cloud.google.com/go/longrunning v0.4.1/go.mod h1:4iWDqhBZ70CvZ6BfETbvam3T8FMvLK+eFj0E6AaRQTo=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
@@ -159,11 +160,17 @@ github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-github/v63 v63.0.0 h1:13xwK/wk9alSokujB9lJkuzdmQuVn2QCPeck76wR3nE=
+github.com/google/go-github/v63 v63.0.0/go.mod h1:IqbcrgUmIcEaioWrGYei/09o+ge5vhffGOcxrO0AfmA=
+github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
+github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -444,6 +451,7 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=

--- a/integration/go.mod
+++ b/integration/go.mod
@@ -1,6 +1,8 @@
 module github.com/openshift/osd-network-verifier/integration
 
-go 1.19
+go 1.21
+
+toolchain go1.22.2
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.17.6

--- a/pkg/data/egress_lists/egress_lists.go
+++ b/pkg/data/egress_lists/egress_lists.go
@@ -8,12 +8,13 @@ package egress_lists
 // that card is complete.
 
 import (
+	"context"
 	_ "embed"
 	"fmt"
-	"os"
-
+	"github.com/google/go-github/v63/github"
 	"github.com/openshift/osd-network-verifier/pkg/helpers"
 	"gopkg.in/yaml.v3"
+	"os"
 )
 
 //go:embed aws-classic.yaml
@@ -25,33 +26,75 @@ var templateAWSHCP string
 //go:embed gcp-classic.yaml
 var templateGCPClassic string
 
-// GetEgressListAsString returns two strings, the sum of which contains all of the URLs
-// within a given platformType's egress list. The first string returned contains all of
-// URLs with tlsDisabled=false, while the second string contains all URLs with tlsDisabled=true
-func GetEgressListAsString(platformType string, region string) (string, string, error) {
-	normalizedPlatformType, err := helpers.GetPlatformType(platformType)
+func GetLocalEgressList(platformType string) (string, error) {
+	switch platformType {
+	case helpers.PlatformGCPClassic, helpers.PlatformGCP:
+		return templateGCPClassic, nil
+	case helpers.PlatformAWSHCP, helpers.PlatformHostedCluster:
+		return templateAWSHCP, nil
+	case helpers.PlatformAWSClassic, helpers.PlatformAWS:
+		return templateAWSClassic, nil
+	default:
+		return "", fmt.Errorf("no egress list registered for platform '%s'", platformType)
+	}
+}
+
+func GetGithubEgressList(platformType string) (*github.RepositoryContent, error) {
+	ghClient := github.NewClient(nil)
+	path := "/pkg/data/egress_lists/"
+	switch platformType {
+	case helpers.PlatformGCPClassic, helpers.PlatformGCP:
+		path += helpers.PlatformGCPClassic
+	case helpers.PlatformAWSHCP, helpers.PlatformHostedCluster:
+		path += helpers.PlatformAWSHCP
+	case helpers.PlatformAWSClassic, helpers.PlatformAWS:
+		path += helpers.PlatformAWSClassic
+	default:
+		return nil, fmt.Errorf("no egress list registered for platform '%s'", platformType)
+	}
+	fileContentResponse, _, _, err := ghClient.Repositories.GetContents(context.TODO(), "openshift", "osd-network-verifier", path, nil)
+	return fileContentResponse, err
+}
+
+// EgressListToString returns two strings, the sum of which contains all the URLs
+// within a given platformType's egress list.
+// The first string returned contains all the URLs with tlsDisabled=false,
+// while the second string contains all URLs with tlsDisabled=true
+func EgressListToString(egressListYamlStr string, variables map[string]string) (string, string, error) {
+	variableMapper := func(varName string) string {
+		return variables[varName]
+	}
+	buf := []byte(os.Expand(egressListYamlStr, variableMapper))
+
+	endpoints := reachabilityConfig{}
+	err := yaml.Unmarshal(buf, &endpoints)
 	if err != nil {
 		return "", "", err
 	}
+	// Build curl-compatible string of URLs
+	var urlListStr string
+	var tlsDisabledURLListStr string
+	for _, endpoint := range endpoints.Endpoints {
+		for _, port := range endpoint.Ports {
+			var protocol string
+			switch port {
+			case 80:
+				protocol = "http"
+			case 443:
+				protocol = "https"
+			default:
+				protocol = "telnet"
+			}
+			urlStr := fmt.Sprintf("%s://%s:%d ", protocol, endpoint.Host, port)
 
-	var egressListYamlStr string
-	switch normalizedPlatformType {
-	case helpers.PlatformGCP:
-		egressListYamlStr = templateGCPClassic
-	case helpers.PlatformHostedCluster:
-		egressListYamlStr = templateAWSHCP
-	case helpers.PlatformAWS:
-		egressListYamlStr = templateAWSClassic
-	default:
-		return "", "", fmt.Errorf("no egress list registered for platform '%s' (normalized to '%s')", platformType, normalizedPlatformType)
+			if endpoint.TLSDisabled {
+				tlsDisabledURLListStr += urlStr
+				continue
+			}
+			urlListStr += urlStr
+		}
 	}
-
-	curlStr, tlsDisabledCurlStr, err := curlStringFromYAML(egressListYamlStr, map[string]string{"AWS_REGION": region})
-	if err != nil {
-		return "", "", fmt.Errorf("unable to parse YAML in egress list for platform '%s' (normalized to '%s')", platformType, normalizedPlatformType)
-	}
-
-	return curlStr, tlsDisabledCurlStr, nil
+	return urlListStr, tlsDisabledURLListStr, nil
 }
 
 // endpoint type (as it appears in the current YAML schema)
@@ -66,46 +109,4 @@ type endpoint struct {
 // Borrowed from osd-network-verifier-golden-ami/build/bin/network-validator.go
 type reachabilityConfig struct {
 	Endpoints []endpoint `yaml:"endpoints"`
-}
-
-// crude YAML to curl-formatted string converter
-// Adapted from osd-network-verifier-golden-ami/build/bin/network-validator.go
-func curlStringFromYAML(yamlStr string, variables map[string]string) (string, string, error) {
-	// Expand variables and parse into endpoints
-	endpoints := reachabilityConfig{}
-	variableMapper := func(varName string) string {
-		return variables[varName]
-	}
-	buf := []byte(os.Expand(yamlStr, variableMapper))
-	err := yaml.Unmarshal(buf, &endpoints)
-	if err != nil {
-		return "", "", err
-	}
-	// Build curl-compatible string of URLs
-	var urlListStr string
-	var tlsDisabledURLListStr string
-	for _, endpoint := range endpoints.Endpoints {
-		// Infer protocol
-		for _, port := range endpoint.Ports {
-			var protocol string
-			switch port {
-			case 80:
-				protocol = "http"
-			case 443:
-				protocol = "https"
-			default:
-				protocol = "telnet"
-			}
-			urlStr := fmt.Sprintf("%s://%s:%d ", protocol, endpoint.Host, port)
-
-			// Separate out URL if TLSDisabled
-			if endpoint.TLSDisabled {
-				tlsDisabledURLListStr += urlStr
-				continue
-			}
-			// If not TLSDisabled, process normally
-			urlListStr += urlStr
-		}
-	}
-	return urlListStr, tlsDisabledURLListStr, nil
 }


### PR DESCRIPTION
[OSD-22628](https://issues.redhat.com//browse/OSD-22628)

- Enhancement/Feature

## What does this PR do? / Related Issues / Jira
Fetch the URL list from github first. Fall back to the local list (current behavior) if that fails, i.e. github is down.

## Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have tested the functionality against gcp / aws, it doesn't cause any regression
- [x] I have added execution results to the PR's readme

## How to test this PR locally / Special Instructions
Pull this commit down and run it exactly as you normally would. You should see a `Using egress URL list from...` line in the console output if the new list is being used.

The file blob can be viewed with https://api.github.com/repos/openshift/osd-network-verifier/git/blobs/<file_sha>

## Logs 

```
./osd-network-verifier egress --subnet-id subnet-0ca196afecc8548bb --security-group-ids sg-041c0bed52e968857
Using region: us-east-1
Using egress URL list from https://api.github.com/repos/openshift/osd-network-verifier/contents/pkg/data/egress_lists/aws-classic.yaml?ref=main at SHA 5fd26419a0a6529a2a692fee0abe591d58542ec3
Created instance with ID: i-02754cba15b7909b2
Deleting instance with ID: i-02754cba15b7909b2
Summary:
All tests passed!
Success
```