### PR TITLE
Add a flag to provide a custom location for the egress URL list

### DIFF
--- a/pkg/data/egress_lists/egress_lists.go
+++ b/pkg/data/egress_lists/egress_lists.go
@@ -105,7 +105,7 @@ type endpoint struct {
 	TLSDisabled bool   `yaml:"tlsDisabled"`
 }
 
-// endpoint list type (as it appears in the current YAML schema)
+// reachabilityConfig list type (as it appears in the current YAML schema)
 // Borrowed from osd-network-verifier-golden-ami/build/bin/network-validator.go
 type reachabilityConfig struct {
 	Endpoints []endpoint `yaml:"endpoints"`

--- a/pkg/verifier/package_verifier.go
+++ b/pkg/verifier/package_verifier.go
@@ -10,8 +10,8 @@ import (
 	"github.com/openshift/osd-network-verifier/pkg/proxy"
 )
 
-// VerifierService defines the behaviors necessary to run verifier completely. Any clients that use that fullfills this interface
-// will be able to run all verifier test
+// VerifierService defines the behaviors necessary to run verifier completely.
+// Any clients that fulfill this interface will be able to run all verifier tests
 type verifierService interface {
 
 	// ValidateEgress validates that all required targets are reachable from the vpcsubnet
@@ -31,6 +31,7 @@ type ValidateEgressInput struct {
 	Timeout                              time.Duration
 	Ctx                                  context.Context
 	SubnetID, CloudImageID, PlatformType string
+	EgressListYaml                       string
 	Proxy                                proxy.ProxyConfig
 	Tags                                 map[string]string
 	AWS                                  AwsEgressConfig
@@ -67,7 +68,7 @@ type GcpEgressConfig struct {
 	Region, Zone, ProjectID, VpcName string
 }
 
-// ValidateEgress pass in a GCP or AWS client that know how to fufill above interface
+// ValidateEgress pass in a GCP or AWS client that know how to fulfill the above interface
 func ValidateEgress(vs verifierService, vei ValidateEgressInput) *output.Output {
 	return vs.ValidateEgress(vei)
 }
@@ -77,7 +78,7 @@ type VerifyDnsInput struct {
 	VpcID string
 }
 
-// VerifyDns pass in a GCP or AWS client that know how to fufill above interface
+// VerifyDns pass in a GCP or AWS client that know how to fulfill the above interface
 func VerifyDns(vs verifierService, vdi VerifyDnsInput) *output.Output {
 	return vs.VerifyDns(vdi)
 }


### PR DESCRIPTION
- Enhancement/Feature

Adds a new flag to allow a user to pass a specific egress URL list.

Resolves [OSD-22629](https://issues.redhat.com//browse/OSD-22629)

To test locally - simply run the verifier as usual but pass in `--egress-list-location` with either an external url or a local file path (absolute or relative to the working directory).