### PR TITLE
add '.yaml' to end of github path

### DIFF
--- a/pkg/data/egress_lists/egress_lists.go
+++ b/pkg/data/egress_lists/egress_lists.go
@@ -52,7 +52,7 @@ func GetGithubEgressList(platformType string) (*github.RepositoryContent, error)
 	default:
 		return nil, fmt.Errorf("no egress list registered for platform '%s'", platformType)
 	}
-	fileContentResponse, _, _, err := ghClient.Repositories.GetContents(context.TODO(), "openshift", "osd-network-verifier", path, nil)
+	fileContentResponse, _, _, err := ghClient.Repositories.GetContents(context.TODO(), "openshift", "osd-network-verifier", fmt.Sprintf("%s.yaml", path), nil)
 	return fileContentResponse, err
 }
 


### PR DESCRIPTION
I committed this in https://github.com/openshift/osd-network-verifier/pull/254 and then never pushed it up 🤦🏻 

```
...
Using region: us-east-1
Using egress URL list from https://api.github.com/repos/openshift/osd-network-verifier/contents/pkg/data/egress_lists/aws-classic.yaml?ref=main at SHA 5fd26419a0a6529a2a692fee0abe591d58542ec3
...
```