### PR TITLE
Tune polling intervals for an overall faster `ValidateEgress()`

### DIFF
--- a/pkg/verifier/aws/aws_verifier.go
+++ b/pkg/verifier/aws/aws_verifier.go
@@ -353,7 +353,7 @@ func (a *AwsVerifier) findUnreachableEndpoints(ctx context.Context, instanceID s
 	a.writeDebugLogs(ctx, "Scraping console output and waiting for user data script to complete...")
 
 	// Periodically scrape console output and analyze the logs for any errors or a successful completion
-	err := helpers.PollImmediate(30*time.Second, 4*time.Minute, func() (bool, error) {
+	err := helpers.PollImmediate(10*time.Second, 270*time.Second, func() (bool, error) {
 		b64EncodedConsoleOutput, err := a.AwsClient.GetConsoleOutput(ctx, &ec2.GetConsoleOutputInput{
 			InstanceId: awsTools.String(instanceID),
 			Latest:     awsTools.Bool(true),


### PR DESCRIPTION
## What does this PR do? / Related Issues / Jira
This PR speeds up `ValidateEgress()` but adjusting how often we're checking for serial console output (i.e., "the `PollImmediate()` loop") and if the EC2 instance has finished terminating. This means that we'll spend less time unnecessarily waiting if, e.g., an instance finishes terminating after 17 seconds, as the previous config would only have checked once at 15s and again at 30s, whereas this new config will check at 3s, 6s, 9s... 15s, and 18s. 

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have tested the functionality against aws, it doesn't cause any regression
- ~~[ ] I have added execution results to the PR's readme~~

## How to test this PR locally / Special Instructions
Keep an eye out for previously unforeseen race conditions or API ratelimiting (unlikely given the still-long intervals). Otherwise, please test this PR as you would any other verifier PR.