### PR TITLE
Add transparant and explicit proxy terraform scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,25 +25,6 @@ The recommended workflow of diagnostic use of ONV is shown in the following flow
 ### Building
 `make build`: Builds `osd-network-verifier` executable in base directory
 
-## Terraform Scripts (AWS)
-
-The Terraform scripts in this repository allow you
-to set up a secure and scalable network infrastructure in AWS for testing.
-It will create a VPC with public, private, and firewall (optional) subnets,
-an Internet Gateway, a NAT Gateway, and a network firewall(optional).
-
-### Getting Started
-
-1. Clone this repository.
-2. Navigate to the Terraform scripts directory: `examples/aws/terraform`.
-3. Copy the `terraform.tfvars.example` file to `terraform.tfvars` and replace the placeholder values with your actual values.
-4. Run `terraform init` to initialize Terraform.
-5. Run `terraform apply` to create the infrastructure.
-
-See the Terraform `README.md` for detailed instructions.
-- [VPC with no Firewall](examples/aws/terraform/vpc/README.md)
-- [VPC with Firewall](examples/aws/terraform/vpc-firewall/README.md)
-
 ## Contributing and Maintenance
 If interested, please fork this repo and create pull requests to the `main` branch.
 
@@ -78,6 +59,14 @@ By default, "X86" is used unless manually overridden by the `--cpu-arch` flag.
 ### IAM Permission Requirement List
 
 Version ID [required for IAM permissions](https://github.com/openshift/osd-network-verifier/blob/main/docs/aws/aws.md#iam-permissions) may need update to match specification in [AWS docs](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_version.html).
+
+### Terraform Scripts (AWS-only)
+
+The Terraform scripts in this repository's (under `/examples/aws/terraform/`) allow you to quickly deploy temporary AWS VPCs for testing the network verifier against several common network scenarios. See each subdirectory's README for more details and usage instructions:
+- [VPC with no firewall](examples/aws/terraform/vpc/README.md)
+- [VPC with an egress firewall](examples/aws/terraform/vpc-firewall/README.md)
+- [VPC with an explicit proxy server](examples/aws/terraform/vpc-proxied-explicit/README.md)
+- [VPC with a transparent proxy server](examples/aws/terraform/vpc-proxied-transparent/README.md)
 
 ## Release Process
 

--- a/examples/aws/terraform/vpc-proxied-explicit/README.md
+++ b/examples/aws/terraform/vpc-proxied-explicit/README.md
@@ -1,0 +1,75 @@
+# Setting up an explicitly (non-transparently) proxied VPC
+The Terraform scripts in this directory will deploy an AWS VPC with a [mitmproxy](https://mitmproxy.org/)-based explicit (non-transparent) HTTP(S) proxy. By definition, explicit proxies require client applications to be explictly configured to use the proxy, usually through the use of environmental variables such as `HTTP_PROXY` and `https_proxy`. If you're looking for the kind of proxy that doesn't require clients to know the proxy address, see [../vpc-proxied-transparent](../vpc-proxied-transparent/).
+
+## Prerequisites
+ * Terraform or OpenTofu
+ * An AWS account with a credentials profile saved to "~/.aws/credentials"
+
+## Setup
+
+> [!IMPORTANT]  
+> The proxied subnet set up by this script will be configured to allow only HTTP[S] (i.e., TCP ports 80 & 443) egress via the generated proxy server. IOW, **anything you launch in the proxied subnet will not be able to connect to the internet unless the application is configured to use the proxy server**. Same goes for any application using ports other than 80 or 443 (e.g., Splunk inputs). If this behavior doesn't work for you, you'll need to add an internet gateway or NAT gateway to the proxied subnet and adjust its routing table accordingly.
+
+1. Clone this repo and `cd` into this directory
+2. Run `terraform init`
+3. Copy/rename "terraform.tfvars.example" to "terraform.tfvars" and fill in the values according to the comments
+4. Run `terraform apply`
+5. Once you see "Apply complete!", wait an additional 3-5 minutes for the proxy server to initialize
+6. Download the proxy's CA cert using the following command
+```bash
+curl --insecure $(terraform output -raw proxy_machine_cert_url) -o ./cacert.pem
+```
+
+And that's it! You may now launch EC2 instances in the "proxied" subnet (`terraform output proxied_subnet_id`) and configure applications on that instance to use the your shiny new proxy server using the `http[s]_proxy_var` outputs that were printed at the end of the `terraform apply`. For example, assuming you spun up a RHEL instance with SSH access in your proxied subnet, you might do something like the following. _Note: if your only goal is to test the network verifier against a proxy, you can skip this conceptual example._
+```bash
+# On your local machine, in the same dir where you ran `terraform apply`
+localhost$ echo "http_proxy='$(terraform output -raw http_proxy_var)' HTTPS_PROXY='$(terraform output -raw https_proxy_var)'"
+http_proxy='http://123.0.0.10:80' HTTPS_PROXY='https://123.0.0.10:80' # Copy this output line to your clipboard
+# Upload the CA cert into the RHEL instance you launched in the proxied subnet
+localhost$ scp ./cacert.pem ec2-user@my-proxied-instance-public-hostname.com:/home/ec2-user/
+# SSH into that RHEL instance
+localhost$ ssh ec2-user@my-proxied-instance-public-hostname.com
+# Now run something like curl, prepending the command with the line you copied earlier
+# Don't forget to tell whatever you're running about the CA cert
+my-proxied-instance$ http_proxy='http://123.0.0.10:80' HTTPS_PROXY='https://123.0.0.10:80' curl -vv --proxy-cacert ~/cacert.pem https://example.com
+[verbose curl output showing connection to the proxy]
+```
+
+Regardless of what application you're running, be sure to add the CA cert you downloaded to your proxied clients' trust store to avoid certificate errors, and be sure to set the necessary `HTTP[S]_PROXY` environmental variables or CLI flags. You [might](https://superuser.com/q/944958) need to set both lowercase and uppercase versions of said environmental variables.
+
+> [!TIP]  
+> Run `terraform apply` again after making any changes to the files in this repo. Your proxy EC2 instance will probably be destroyed and recreated in the process, resulting in new IP addresses, CA certs, and passwords.
+
+## Usage
+### Launch the network verifier in the proxied subnet
+Run the following command on your workstation to launch an EC2 VM that will make a series of HTTPS requests that will be explicitly proxied. Be sure to replace `default` with the name of your AWS credentials profile (see `profile` in "terraform.tfvars"). 
+```bash
+osd-network-verifier egress --profile=default --subnet-id=$(terraform output -raw proxied_subnet_id) --region=$(terraform output -raw region) --cacert=cacert.pem --http-proxy="$(terraform output -raw http_proxy_var)" --https-proxy="$(terraform output -raw https_proxy_var)"
+```
+Remember that non-HTTP(S) connections are expected to fail, so you can safely ignore the verifier reporting that the Splunk input endpoints (which use port 9997) are blocked.
+
+### View/manipulate traffic flowing through the proxy
+> [!NOTE]  
+> The proxy webUI is HTTPS-secured but uses a runtime-generated self-signed certificate. As a result, you'll probably have to click-past some scary browser warnings (usually under "Advanced > Proceed to [...] (unsafe)"). This is also why we have to use curl's `--insecure` flag when downloading the proxy CA cert (which is unrelated to the webUI's self-signed cert).
+
+Run the following command to print credentials you can use to access the mitmproxy's webUI in your browser.
+```bash
+for V in url username password; do echo "$V: $(terraform output -raw proxy_webui_${V})"; done
+```
+If you're having trouble connecting to the webUI (other than certificate warnings; see above note), try disabling any VPNs or browser proxy extensions/configurations. Also ensure that your workstation's IP address is covered by the value you set for `developer_cidr_block` in "terraform.tfvars". As an insecure last resort, you can set `developer_cidr_block` to "0.0.0.0/0" to allow the entire internet to access your proxy machine.
+
+### SSH into the proxy machine
+Run the following command to log into the RHEL 9 machine hosting the proxy server. Add `-i [path to your private key]` to the command if the `proxy_machine_ssh_pubkey` you provided in "terraform.tfvars" does not correspond to your default private key (usually "~/.ssh/id_rsa"). See the paragraph above if you encounter connection issues.
+```bash
+ssh $(terraform output -raw proxy_machine_ssh_url) 
+```
+Once logged in, you can see the status of the proxy server using `sudo systemctl status mitmproxy`. The proxy's webUI is running on port 8081, but traffic from the outside world is reverse-proxied through [Caddy](https://caddyserver.com/) (via port 8443) first; you can check its status using `sudo systemctl status caddy`.
+
+Remember that the proxy machine (and therefore changes you make to it via SSH) will likely be destroyed next time you run `terraform apply`. To make your changes more durable, add commands or [cloud-init](https://cloudinit.readthedocs.io/en/latest/reference/modules.html) directives to [assets/userdata.yaml.tpl](assets/userdata.yaml.tpl).
+
+## Cleanup
+To delete the proxy server, the surrounding subnets/VPC, and all other AWS resources created by this script, simply run `terraform destroy`.
+
+
+
+

--- a/examples/aws/terraform/vpc-proxied-explicit/assets/Caddyfile.tpl
+++ b/examples/aws/terraform/vpc-proxied-explicit/assets/Caddyfile.tpl
@@ -1,0 +1,25 @@
+{
+	skip_install_trust
+	servers {
+		protocols h1 h2
+    }
+}
+:8443 {
+	tls internal {
+		on_demand
+	}
+	basic_auth {
+		${proxy_webui_username} ${proxy_webui_password_hash}
+	}
+	handle /mitmproxy-ca-cert.pem {
+		root * /usr/share/caddy
+		file_server
+	}
+	handle {
+		reverse_proxy 127.0.0.1:8081 {
+			header_up Host "127.0.0.1:8081"
+			header_up Origin "http://127.0.0.1:8081"
+			header_up -X-Frame-Options
+		}
+	}
+}

--- a/examples/aws/terraform/vpc-proxied-explicit/assets/mitmproxy-sysctl.conf
+++ b/examples/aws/terraform/vpc-proxied-explicit/assets/mitmproxy-sysctl.conf
@@ -1,0 +1,3 @@
+net.ipv4.ip_forward = 1
+net.ipv6.conf.all.forwarding = 1
+net.ipv4.conf.all.send_redirects = 0

--- a/examples/aws/terraform/vpc-proxied-explicit/assets/mitmproxy.service
+++ b/examples/aws/terraform/vpc-proxied-explicit/assets/mitmproxy.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=mitmproxy web daemon
+After=network.target
+Wants=network.target iptables.service
+
+[Service]
+Type=simple
+User=root
+ExecStart=/usr/bin/mitmweb --web-port=8081 --web-host=0.0.0.0 --no-web-open-browser --showhost
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/examples/aws/terraform/vpc-proxied-explicit/assets/userdata.yaml.tpl
+++ b/examples/aws/terraform/vpc-proxied-explicit/assets/userdata.yaml.tpl
@@ -1,0 +1,59 @@
+#cloud-config
+#package_update: true
+#package_upgrade: true
+yum_repos:
+  caddy:
+    name: Copr repo for caddy owned by @caddy
+    baseurl: https://download.copr.fedorainfracloud.org/results/@caddy/caddy/epel-9-$basearch/
+    type: rpm-md
+    skip_if_unavailable: true
+    gpgcheck: 1
+    gpgkey: https://download.copr.fedorainfracloud.org/results/@caddy/caddy/pubkey.gpg
+    repo_gpgcheck: 0
+    enabled: 1
+    enabled_metadata: 1
+packages:
+  - iptables
+  - iptables-nft-services
+  - caddy
+write_files:
+- encoding: b64
+  content: ${mitmproxy_sysctl_b64}
+  owner: root:root
+  path: /etc/sysctl.d/mitmproxy.conf
+  permissions: '0644'
+- encoding: b64
+  content:  ${mitmproxy_service_b64}
+  owner: root:root
+  path: /etc/systemd/system/mitmproxy.service
+  permissions: '0644'
+- encoding: b64
+  content: ${caddyfile_b64}
+  owner: root:root
+  path: /etc/caddy/Caddyfile
+  permissions: '0644'
+runcmd:
+- sysctl -p /etc/sysctl.d/mitmproxy.conf
+- curl -s https://downloads.mitmproxy.org/10.3.0/mitmproxy-10.3.0-linux-x86_64.tar.gz -o - | tar -C /usr/bin/ -xzf -
+- iptables -F
+- iptables -X
+- iptables -t nat -F
+- iptables -t nat -X
+- iptables -t mangle -F
+- iptables -t mangle -X
+- iptables -t raw -F
+- iptables -t raw -X
+- iptables -t security -F
+- iptables -t security -X
+- iptables -P INPUT ACCEPT
+- iptables -P FORWARD ACCEPT
+- iptables -P OUTPUT ACCEPT
+- iptables -t nat -A PREROUTING -i eth0 -p tcp --dport 80 -j REDIRECT --to-port 8080
+- iptables -t nat -A PREROUTING -i eth0 -p tcp --dport 443 -j REDIRECT --to-port 8080
+- ip6tables -t nat -A PREROUTING -i eth0 -p tcp --dport 80 -j REDIRECT --to-port 8080
+- ip6tables -t nat -A PREROUTING -i eth0 -p tcp --dport 443 -j REDIRECT --to-port 8080
+- /sbin/iptables-save > /etc/sysconfig/iptables
+- /sbin/ip6tables-save > /etc/sysconfig/ip6tables
+- systemctl daemon-reload
+- systemctl enable --now iptables.service mitmproxy.service caddy.service
+- sleep 10 && cp ~/.mitmproxy/mitmproxy-ca-cert.pem /usr/share/caddy/ && chmod -R 755 /usr/share/caddy/mitmproxy-ca-cert.pem

--- a/examples/aws/terraform/vpc-proxied-explicit/main.tf
+++ b/examples/aws/terraform/vpc-proxied-explicit/main.tf
@@ -197,10 +197,6 @@ output "https_proxy_var" {
   description = "value for HTTPS_PROXY environmental variable"
   value       = "https://${aws_instance.proxy_machine.private_ip}:443"
 }
-# output "public_subnet_id" {
-#   description = "The ID of the Public Subnet"
-#   value       = aws_subnet.public.id
-# }
 
 ## DATA
 # Get the current AWS region

--- a/examples/aws/terraform/vpc-proxied-explicit/main.tf
+++ b/examples/aws/terraform/vpc-proxied-explicit/main.tf
@@ -1,0 +1,234 @@
+# AWS provider configuration
+provider "aws" {
+  profile = var.profile # AWS profile
+  region  = var.region  # AWS region
+}
+
+## RESOURCES
+# Create a VPC
+resource "aws_vpc" "main" {
+  cidr_block           = var.vpc_cidr_block
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+  tags                 = { Name = "${var.name_prefix}-vpc" }
+}
+
+# Create an Internet Gateway and attach it to the VPC
+resource "aws_internet_gateway" "igw" {
+  vpc_id = aws_vpc.main.id
+  tags   = { Name = "${var.name_prefix}-igw" }
+}
+
+# Create a public subnet within the VPC (where the proxy machine will live)
+resource "aws_subnet" "public" {
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = var.public_subnet_cidr_block # CIDR block for public subnet
+  availability_zone       = var.availability_zone
+  map_public_ip_on_launch = true
+  tags                    = { Name = "${var.name_prefix}-public" }
+}
+
+# Create a route table for the public subnet
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+  tags   = { Name = "${var.name_prefix}-public-rtb" }
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.igw.id
+  }
+}
+
+# Associate the public subnet with its route table (skipping this because default RTB is fine for public sub)
+resource "aws_route_table_association" "public" {
+  subnet_id      = aws_subnet.public.id
+  route_table_id = aws_route_table.public.id
+}
+
+# Create a security group for the proxy machine (rules below)
+resource "aws_security_group" "proxy_machine_sg" {
+  name_prefix = var.name_prefix
+  description = "Allow all outbound traffic and inbound traffic from proxied subnet or developer SSH client"
+  vpc_id      = aws_vpc.main.id
+}
+# proxy_machine_sg: Allow all ingress traffic from the proxied subnet
+resource "aws_vpc_security_group_ingress_rule" "allow_proxied_traffic" {
+  security_group_id = aws_security_group.proxy_machine_sg.id
+  cidr_ipv4         = aws_subnet.proxied.cidr_block
+  ip_protocol       = "-1" # semantically equivalent to all ports
+}
+# proxy_machine_sg: Allow SSH traffic from the developer's IP
+resource "aws_vpc_security_group_ingress_rule" "allow_developer_ssh" {
+  security_group_id = aws_security_group.proxy_machine_sg.id
+  cidr_ipv4         = var.developer_cidr_block
+  from_port         = 22
+  to_port           = 22
+  ip_protocol       = "tcp"
+}
+# proxy_machine_sg: Allow webUI traffic from the developer's IP
+resource "aws_vpc_security_group_ingress_rule" "allow_developer_webui" {
+  security_group_id = aws_security_group.proxy_machine_sg.id
+  cidr_ipv4         = var.developer_cidr_block
+  from_port         = 8443
+  to_port           = 8443
+  ip_protocol       = "tcp"
+}
+# proxy_machine_sg: Allow all IPv4 egress traffic from the proxy
+resource "aws_vpc_security_group_egress_rule" "allow_all_traffic_ipv4" {
+  security_group_id = aws_security_group.proxy_machine_sg.id
+  cidr_ipv4         = "0.0.0.0/0"
+  ip_protocol       = "-1" # semantically equivalent to all ports
+}
+# proxy_machine_sg: Allow all IPv6 egress traffic from the proxy
+resource "aws_vpc_security_group_egress_rule" "allow_all_traffic_ipv6" {
+  security_group_id = aws_security_group.proxy_machine_sg.id
+  cidr_ipv6         = "::/0"
+  ip_protocol       = "-1" # semantically equivalent to all ports
+}
+# End proxy_machine_sg rules
+
+# Create an SSH keypair that the user can use for debugging the proxy_machine
+resource "aws_key_pair" "proxy_machine_key" {
+  key_name_prefix = var.name_prefix
+  public_key      = var.proxy_machine_ssh_pubkey
+}
+
+# Generate a random password for the proxy web UI
+resource "random_password" "proxy_webui_password" {
+  length  = 16
+  special = false
+}
+
+# Create the proxy EC2 instance inside the public subnet
+resource "aws_instance" "proxy_machine" {
+  ami               = data.aws_ami.rhel9.id
+  instance_type     = "t3.micro"
+  key_name          = aws_key_pair.proxy_machine_key.key_name # SSH key for debugging
+  availability_zone = var.availability_zone
+  tags              = { Name = "${var.name_prefix}-proxy-machine" }
+
+  user_data = templatefile(
+    "assets/userdata.yaml.tpl",
+    {
+      mitmproxy_sysctl_b64  = filebase64("assets/mitmproxy-sysctl.conf")
+      mitmproxy_service_b64 = filebase64("assets/mitmproxy.service")
+      caddyfile_b64 = base64encode(templatefile(
+        "assets/Caddyfile.tpl",
+        {
+          proxy_webui_password_hash = random_password.proxy_webui_password.bcrypt_hash
+          proxy_webui_username      = var.proxy_webui_username
+        }
+      ))
+    }
+  )
+  user_data_replace_on_change = true # Destroy and re-create this instance if user-data.yaml changes
+
+  subnet_id                   = aws_subnet.public.id
+  vpc_security_group_ids      = [aws_security_group.proxy_machine_sg.id]
+  associate_public_ip_address = true  # Necessary b/c we're not using a NAT gateway
+  source_dest_check           = false # Critical for correct routing
+}
+
+# Create a proxied subnet (where the test/"captive" machines will live)
+resource "aws_subnet" "proxied" {
+  vpc_id            = aws_vpc.main.id
+  availability_zone = var.availability_zone
+  cidr_block        = var.proxied_subnet_cidr_block
+  tags              = { Name = "${var.name_prefix}-proxied" }
+}
+
+# Create a route table for the proxied subnet that routes all traffic into the proxy_machine
+resource "aws_route_table" "proxied" {
+  vpc_id = aws_vpc.main.id
+  tags   = { Name = "${var.name_prefix}-proxied-rtb" }
+
+  route {
+    cidr_block           = var.proxied_subnet_cidr_block
+    network_interface_id = aws_instance.proxy_machine.primary_network_interface_id
+  }
+}
+
+# Associate the proxied subnet with its route table
+resource "aws_route_table_association" "proxied" {
+  subnet_id      = aws_subnet.proxied.id      # ID of proxied subnet
+  route_table_id = aws_route_table.proxied.id # ID of proxied route table
+}
+
+## OUTPUTS
+output "region" {
+  description = "VPC region"
+  value       = data.aws_region.current.name
+}
+output "proxy_machine_instance_id" {
+  description = "Proxy machine instance ID"
+  value       = aws_instance.proxy_machine.id
+}
+output "proxy_machine_ssh_url" {
+  description = "SSH URL for logging into the proxy machine"
+  value       = "ssh://ec2-user@${aws_instance.proxy_machine.public_ip}"
+}
+output "proxy_webui_url" {
+  description = "URL for accessing the proxy webUI (available in 2-5 minutes)"
+  value       = "https://${aws_instance.proxy_machine.public_ip}:8443/"
+}
+output "proxy_webui_username" {
+  description = "Proxy webUI username"
+  value       = var.proxy_webui_username
+}
+output "proxy_webui_password" {
+  description = "Proxy webUI password"
+  value       = random_password.proxy_webui_password.result
+  sensitive   = true
+}
+output "proxy_machine_cert_url" {
+  description = "Credentialed URL for downloading the proxy CA cert (available in 2-5 minutes)"
+  value       = "https://${var.proxy_webui_username}:${random_password.proxy_webui_password.result}@${aws_instance.proxy_machine.public_ip}:8443/mitmproxy-ca-cert.pem"
+  sensitive   = true
+}
+output "proxied_subnet_id" {
+  description = "Proxied subnet ID (launch your test/'captive' instances here)"
+  value       = aws_subnet.proxied.id
+}
+output "http_proxy_var" {
+  description = "value for http_proxy environmental variable"
+  value       = "http://${aws_instance.proxy_machine.private_ip}:80"
+}
+output "https_proxy_var" {
+  description = "value for HTTPS_PROXY environmental variable"
+  value       = "https://${aws_instance.proxy_machine.private_ip}:443"
+}
+# output "public_subnet_id" {
+#   description = "The ID of the Public Subnet"
+#   value       = aws_subnet.public.id
+# }
+
+## DATA
+# Get the current AWS region
+data "aws_region" "current" {}
+
+# Automatic lookup of the latest official RHEL 9 AMI
+data "aws_ami" "rhel9" {
+  most_recent = true
+
+  filter {
+    name   = "platform-details"
+    values = ["Red Hat Enterprise Linux"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+
+  filter {
+    name   = "root-device-type"
+    values = ["ebs"]
+  }
+
+  filter {
+    name   = "manifest-location"
+    values = ["amazon/RHEL-9.*_HVM-*-x86_64-*-Hourly2-GP2"]
+  }
+
+  owners = ["309956199498"] # Amazon's "Official Red Hat" account
+}

--- a/examples/aws/terraform/vpc-proxied-explicit/terraform.tfvars.example
+++ b/examples/aws/terraform/vpc-proxied-explicit/terraform.tfvars.example
@@ -1,0 +1,37 @@
+## Sample Variables 
+## Fill in the values below and rename me to "terraform.tfvars" 
+
+# Your AWS Profile
+# This profile should be configured in your AWS credentials file, typically located at ~/.aws/credentials on Unix-based systems and C:\Users\USERNAME\.aws\credentials on Windows. 
+# The profile configuration should look something like this:
+# 
+# [default]
+# aws_access_key_id = YOUR_ACCESS_KEY
+# aws_secret_access_key = YOUR_SECRET_KEY
+#
+profile = "default"
+
+# The AWS region where you want to create your resources
+region = "us-east-1"
+
+# The availability zone within the region where you want to create your subnets
+availability_zone = "us-east-1a"
+
+# The CIDR block for your VPC
+vpc_cidr_block = "10.0.0.0/16"
+
+# The CIDR block for your public subnet within your VPC
+public_subnet_cidr_block = "10.0.0.0/24"
+
+# The CIDR block for your proxied subnet within your VPC
+proxied_subnet_cidr_block = "10.0.1.0/24"
+
+# A prefix to add to the Name tag associated with most of the resources created by these scripts
+name_prefix = "transparent-proxy"
+
+# SSH public key to use for ec2-user@proxy-machine
+proxy_machine_ssh_pubkey = "ssh-rsa AAAAB3N...SrbX8ZbabVohBK41 replaceme@example.com"
+
+# A CIDR block containing your workstation's IP, for SSH/webUI access to the proxy machine for debugging. 
+# Running "echo $(curl -s ipv4.icanhazip.com)/32' should produce a sane default value
+developer_cidr_block = "123.123.123.123/32"

--- a/examples/aws/terraform/vpc-proxied-explicit/variables.tf
+++ b/examples/aws/terraform/vpc-proxied-explicit/variables.tf
@@ -1,0 +1,68 @@
+# AWS Profile to use
+variable "profile" {
+  description = "AWS Profile to use"
+  type        = string
+  default     = "default"
+}
+
+# The AWS Region where resources will be created
+variable "region" {
+  description = "AWS Region"
+  type        = string
+  default     = "us-east-1" # Default to US East (N. Virginia)
+}
+
+# The availability zone where the subnets will be created
+variable "availability_zone" {
+  description = "The availability zone where the subnets will be created"
+  type        = string
+  default     = "us-east-1a" # Default to US East (N. Virginia) AZ a
+}
+
+# CIDR block for the VPC
+variable "vpc_cidr_block" {
+  description = "CIDR block for the VPC"
+  type        = string
+  default     = "10.0.0.0/16" # Default to a /16 block within the 10.0.0.0 private network
+}
+
+# CIDR block for the public subnet
+variable "public_subnet_cidr_block" {
+  description = "CIDR block for the public subnet"
+  type        = string
+  default     = "10.0.0.0/24" # Default to a /24 block within the 10.0.0.0 private network
+}
+
+# CIDR block for the private subnet
+variable "proxied_subnet_cidr_block" {
+  description = "CIDR block for the private subnet"
+  type        = string
+  default     = "10.0.1.0/24" # Default to a /24 block within the 10.0.0.0 private network
+}
+
+# User/developer's CIDR block for SSH/webUI access to the proxy machine for debugging
+variable "developer_cidr_block" {
+  description = "A CIDR block containing your workstation's IP, for SSH/webUI access to the proxy machine for debugging. The output of 'echo $(curl -s ipv4.icanhazip.com)/32' is a sane default"
+  type        = string
+}
+
+# Username to use for the proxy machine web UI
+variable "proxy_webui_username" {
+  description = "Username to use for the proxy machine web UI"
+  type        = string
+  default     = "developer"
+}
+
+# Prefix to add to name tags
+variable "name_prefix" {
+  description = "prefix to add to the Name tag associated with most of the resources created by these scripts"
+  type        = string
+  default     = "transparent-proxy-"
+}
+
+# SSH public key to use for ec2-user@proxy-machine
+variable "proxy_machine_ssh_pubkey" {
+  description = "SSH public key to use for ec2-user@proxy-machine"
+  type        = string
+}
+

--- a/examples/aws/terraform/vpc-proxied-explicit/variables.tf
+++ b/examples/aws/terraform/vpc-proxied-explicit/variables.tf
@@ -57,7 +57,7 @@ variable "proxy_webui_username" {
 variable "name_prefix" {
   description = "prefix to add to the Name tag associated with most of the resources created by these scripts"
   type        = string
-  default     = "transparent-proxy-"
+  default     = "explicit-proxy-"
 }
 
 # SSH public key to use for ec2-user@proxy-machine

--- a/examples/aws/terraform/vpc-proxied-transparent/README.md
+++ b/examples/aws/terraform/vpc-proxied-transparent/README.md
@@ -1,0 +1,64 @@
+# Setting up a transparently-proxied VPC
+The Terraform scripts in this directory will deploy an AWS VPC with a [mitmproxy](https://mitmproxy.org/)-based transparent HTTP(S) proxy. By definition, transparent proxies work _without_ requiring client applications to be explictly configured to use the proxy — i.e., you should not be setting `HTTP[S]_PROXY` or `https_proxy` environmental variables or CLI flags. Instead, the network's routing tables are configured to route all traffic from the "proxied subnet" through the proxy machine, regardless of the traffic's intended destination.
+
+> [!WARNING]  
+> Transparent proxies are less common than explicit (non-transparent) proxies. Confirm that whatever you're working on is actually asking you to use/test against a transparent proxy. If not, see [../vpc-proxied-explicit](../vpc-proxied-explicit/).
+
+## Prerequisites
+ * Terraform or OpenTofu
+ * An AWS account with a credentials profile saved to "~/.aws/credentials"
+
+## Setup
+
+> [!IMPORTANT]  
+> The proxied subnet set up by this script will be configured to allow only HTTP[S] (i.e., TCP ports 80 & 443) egress via the generated proxy server. IOW, **anything you launch in the proxied subnet will not be able to connect to the internet via any ports other than TCP ports 80 or 443.** This behavior is enforced by the proxied subnet's routing table and proxy server's prerouting rules, and such routing is required to implement the "transparent" part of the proxy.
+
+1. Clone this repo and `cd` into this directory
+2. Run `terraform init`
+3. Copy/rename "terraform.tfvars.example" to "terraform.tfvars" and fill in the values according to the comments
+4. Run `terraform apply`
+5. Once you see "Apply complete!", wait an additional 3-5 minutes for the proxy server to initialize
+6. Download the proxy's CA cert using the following command
+```bash
+curl --insecure $(terraform output -raw proxy_machine_cert_url) -o ./cacert.pem
+```
+
+And that's it! Anything you launch in the "proxied" subnet (`terraform output proxied_subnet_id`) will have its HTTP(S) traffic transparently routed through your proxy machine. Be sure to add the CA cert you downloaded to your proxied clients' trust store to avoid certificate errors, and be sure NOT to set any `HTTP[S]_PROXY` values (as you might for an explicit proxy).
+
+> [!TIP]  
+> Run `terraform apply` again after making any changes to the files in this repo. Your proxy EC2 instance will probably be destroyed and recreated in the process, resulting in new IP addresses, CA certs, and passwords.
+
+## Usage
+### Launch the network verifier in the proxied subnet
+Run the following command on your workstation to launch an EC2 VM that will make a series of HTTPS requests that will be transparently proxied. Be sure to replace `default` with the name of your AWS credentials profile (see `profile` in "terraform.tfvars").
+```bash
+osd-network-verifier egress --profile=default --subnet-id=$(terraform output -raw proxied_subnet_id) --region=$(terraform output -raw region) --cacert=cacert.pem
+```
+Notice how we're not setting the `--http[s]-proxy` flags; such flags should only be set for explicitly/non-transparently-proxied networks. Also, remember that non-HTTP(S) connections are expected to fail, so you can safely ignore the verifier reporting that the Splunk input endpoints (which use port 9997) are blocked.
+
+
+### View/manipulate traffic flowing through the proxy
+> [!NOTE]  
+> The proxy webUI is HTTPS-secured but uses a runtime-generated self-signed certificate. As a result, you'll probably have to click-past some scary browser warnings (usually under "Advanced > Proceed to [...] (unsafe)"). This is also why we have to use curl's `--insecure` flag when downloading the proxy CA cert (which is unrelated to the webUI's self-signed cert).
+
+Run the following command to print credentials you can use to access the mitmproxy's webUI in your browser.
+```bash
+for V in url username password; do echo "$V: $(terraform output -raw proxy_webui_${V})"; done
+```
+If you're having trouble connecting to the webUI (other than certificate warnings; see above note), try disabling any VPNs or browser proxy extensions/configurations. Also ensure that your workstation's IP address is covered by the value you set for `developer_cidr_block` in "terraform.tfvars". As an insecure last resort, you can set `developer_cidr_block` to "0.0.0.0/0" to allow the entire internet to access your proxy machine.
+
+### SSH into the proxy machine
+Run the following command to log into the RHEL 9 machine hosting the proxy server. Add `-i [path to your private key]` to the command if the `proxy_machine_ssh_pubkey` you provided in "terraform.tfvars" does not correspond to your default private key (usually "~/.ssh/id_rsa"). See the paragraph above if you encounter connection issues.
+```bash
+ssh $(terraform output -raw proxy_machine_ssh_url) 
+```
+Once logged in, you can see the status of the proxy server using `sudo systemctl status mitmproxy`. The proxy's webUI is running on port 8081, but traffic from the outside world is reverse-proxied through [Caddy](https://caddyserver.com/) (via port 8443) first; you can check its status using `sudo systemctl status caddy`.
+
+Remember that the proxy machine (and therefore changes you make to it via SSH) will likely be destroyed next time you run `terraform apply`. To make your changes more durable, add commands or [cloud-init](https://cloudinit.readthedocs.io/en/latest/reference/modules.html) directives to [assets/userdata.yaml.tpl](assets/userdata.yaml.tpl).
+
+## Cleanup
+To delete the proxy server, the surrounding subnets/VPC, and all other AWS resources created by this script, simply run `terraform destroy`.
+
+
+
+

--- a/examples/aws/terraform/vpc-proxied-transparent/assets/Caddyfile.tpl
+++ b/examples/aws/terraform/vpc-proxied-transparent/assets/Caddyfile.tpl
@@ -1,0 +1,25 @@
+{
+	skip_install_trust
+	servers {
+		protocols h1 h2
+    }
+}
+:8443 {
+	tls internal {
+		on_demand
+	}
+	basic_auth {
+		${proxy_webui_username} ${proxy_webui_password_hash}
+	}
+	handle /mitmproxy-ca-cert.pem {
+		root * /usr/share/caddy
+		file_server
+	}
+	handle {
+		reverse_proxy 127.0.0.1:8081 {
+			header_up Host "127.0.0.1:8081"
+			header_up Origin "http://127.0.0.1:8081"
+			header_up -X-Frame-Options
+		}
+	}
+}

--- a/examples/aws/terraform/vpc-proxied-transparent/assets/mitmproxy-sysctl.conf
+++ b/examples/aws/terraform/vpc-proxied-transparent/assets/mitmproxy-sysctl.conf
@@ -1,0 +1,3 @@
+net.ipv4.ip_forward = 1
+net.ipv6.conf.all.forwarding = 1
+net.ipv4.conf.all.send_redirects = 0

--- a/examples/aws/terraform/vpc-proxied-transparent/assets/mitmproxy.service
+++ b/examples/aws/terraform/vpc-proxied-transparent/assets/mitmproxy.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=mitmproxy web daemon
+After=network.target
+Wants=network.target iptables.service
+
+[Service]
+Type=simple
+User=root
+ExecStart=/usr/bin/mitmweb --web-port=8081 --web-host=0.0.0.0 --no-web-open-browser --mode=transparent --showhost
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/examples/aws/terraform/vpc-proxied-transparent/assets/userdata.yaml.tpl
+++ b/examples/aws/terraform/vpc-proxied-transparent/assets/userdata.yaml.tpl
@@ -1,0 +1,59 @@
+#cloud-config
+#package_update: true
+#package_upgrade: true
+yum_repos:
+  caddy:
+    name: Copr repo for caddy owned by @caddy
+    baseurl: https://download.copr.fedorainfracloud.org/results/@caddy/caddy/epel-9-$basearch/
+    type: rpm-md
+    skip_if_unavailable: true
+    gpgcheck: 1
+    gpgkey: https://download.copr.fedorainfracloud.org/results/@caddy/caddy/pubkey.gpg
+    repo_gpgcheck: 0
+    enabled: 1
+    enabled_metadata: 1
+packages:
+  - iptables
+  - iptables-nft-services
+  - caddy
+write_files:
+- encoding: b64
+  content: ${mitmproxy_sysctl_b64}
+  owner: root:root
+  path: /etc/sysctl.d/mitmproxy.conf
+  permissions: '0644'
+- encoding: b64
+  content:  ${mitmproxy_service_b64}
+  owner: root:root
+  path: /etc/systemd/system/mitmproxy.service
+  permissions: '0644'
+- encoding: b64
+  content: ${caddyfile_b64}
+  owner: root:root
+  path: /etc/caddy/Caddyfile
+  permissions: '0644'
+runcmd:
+- sysctl -p /etc/sysctl.d/mitmproxy.conf
+- curl -s https://downloads.mitmproxy.org/10.3.0/mitmproxy-10.3.0-linux-x86_64.tar.gz -o - | tar -C /usr/bin/ -xzf -
+- iptables -F
+- iptables -X
+- iptables -t nat -F
+- iptables -t nat -X
+- iptables -t mangle -F
+- iptables -t mangle -X
+- iptables -t raw -F
+- iptables -t raw -X
+- iptables -t security -F
+- iptables -t security -X
+- iptables -P INPUT ACCEPT
+- iptables -P FORWARD ACCEPT
+- iptables -P OUTPUT ACCEPT
+- iptables -t nat -A PREROUTING -i eth0 -p tcp --dport 80 -j REDIRECT --to-port 8080
+- iptables -t nat -A PREROUTING -i eth0 -p tcp --dport 443 -j REDIRECT --to-port 8080
+- ip6tables -t nat -A PREROUTING -i eth0 -p tcp --dport 80 -j REDIRECT --to-port 8080
+- ip6tables -t nat -A PREROUTING -i eth0 -p tcp --dport 443 -j REDIRECT --to-port 8080
+- /sbin/iptables-save > /etc/sysconfig/iptables
+- /sbin/ip6tables-save > /etc/sysconfig/ip6tables
+- systemctl daemon-reload
+- systemctl enable --now iptables.service mitmproxy.service caddy.service
+- sleep 10 && cp ~/.mitmproxy/mitmproxy-ca-cert.pem /usr/share/caddy/ && chmod -R 755 /usr/share/caddy/mitmproxy-ca-cert.pem

--- a/examples/aws/terraform/vpc-proxied-transparent/main.tf
+++ b/examples/aws/terraform/vpc-proxied-transparent/main.tf
@@ -189,10 +189,6 @@ output "proxied_subnet_id" {
   description = "Proxied subnet ID (launch your test/'captive' instances here)"
   value       = aws_subnet.proxied.id
 }
-# output "public_subnet_id" {
-#   description = "The ID of the Public Subnet"
-#   value       = aws_subnet.public.id
-# }
 
 ## DATA
 # Get the current AWS region

--- a/examples/aws/terraform/vpc-proxied-transparent/main.tf
+++ b/examples/aws/terraform/vpc-proxied-transparent/main.tf
@@ -1,0 +1,226 @@
+# AWS provider configuration
+provider "aws" {
+  profile = var.profile # AWS profile
+  region  = var.region  # AWS region
+}
+
+## RESOURCES
+# Create a VPC
+resource "aws_vpc" "main" {
+  cidr_block           = var.vpc_cidr_block
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+  tags                 = { Name = "${var.name_prefix}-vpc" }
+}
+
+# Create an Internet Gateway and attach it to the VPC
+resource "aws_internet_gateway" "igw" {
+  vpc_id = aws_vpc.main.id
+  tags   = { Name = "${var.name_prefix}-igw" }
+}
+
+# Create a public subnet within the VPC (where the proxy machine will live)
+resource "aws_subnet" "public" {
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = var.public_subnet_cidr_block # CIDR block for public subnet
+  availability_zone       = var.availability_zone
+  map_public_ip_on_launch = true
+  tags                    = { Name = "${var.name_prefix}-public" }
+}
+
+# Create a route table for the public subnet
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+  tags   = { Name = "${var.name_prefix}-public-rtb" }
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.igw.id
+  }
+}
+
+# Associate the public subnet with its route table (skipping this because default RTB is fine for public sub)
+resource "aws_route_table_association" "public" {
+  subnet_id      = aws_subnet.public.id
+  route_table_id = aws_route_table.public.id
+}
+
+# Create a security group for the proxy machine (rules below)
+resource "aws_security_group" "proxy_machine_sg" {
+  name_prefix = var.name_prefix
+  description = "Allow all outbound traffic and inbound traffic from proxied subnet or developer SSH client"
+  vpc_id      = aws_vpc.main.id
+}
+# proxy_machine_sg: Allow all ingress traffic from the proxied subnet
+resource "aws_vpc_security_group_ingress_rule" "allow_proxied_traffic" {
+  security_group_id = aws_security_group.proxy_machine_sg.id
+  cidr_ipv4         = aws_subnet.proxied.cidr_block
+  ip_protocol       = "-1" # semantically equivalent to all ports
+}
+# proxy_machine_sg: Allow SSH traffic from the developer's IP
+resource "aws_vpc_security_group_ingress_rule" "allow_developer_ssh" {
+  security_group_id = aws_security_group.proxy_machine_sg.id
+  cidr_ipv4         = var.developer_cidr_block
+  from_port         = 22
+  to_port           = 22
+  ip_protocol       = "tcp"
+}
+# proxy_machine_sg: Allow webUI traffic from the developer's IP
+resource "aws_vpc_security_group_ingress_rule" "allow_developer_webui" {
+  security_group_id = aws_security_group.proxy_machine_sg.id
+  cidr_ipv4         = var.developer_cidr_block
+  from_port         = 8443
+  to_port           = 8443
+  ip_protocol       = "tcp"
+}
+# proxy_machine_sg: Allow all IPv4 egress traffic from the proxy
+resource "aws_vpc_security_group_egress_rule" "allow_all_traffic_ipv4" {
+  security_group_id = aws_security_group.proxy_machine_sg.id
+  cidr_ipv4         = "0.0.0.0/0"
+  ip_protocol       = "-1" # semantically equivalent to all ports
+}
+# proxy_machine_sg: Allow all IPv6 egress traffic from the proxy
+resource "aws_vpc_security_group_egress_rule" "allow_all_traffic_ipv6" {
+  security_group_id = aws_security_group.proxy_machine_sg.id
+  cidr_ipv6         = "::/0"
+  ip_protocol       = "-1" # semantically equivalent to all ports
+}
+# End proxy_machine_sg rules
+
+# Create an SSH keypair that the user can use for debugging the proxy_machine
+resource "aws_key_pair" "proxy_machine_key" {
+  key_name_prefix = var.name_prefix
+  public_key      = var.proxy_machine_ssh_pubkey
+}
+
+# Generate a random password for the proxy web UI
+resource "random_password" "proxy_webui_password" {
+  length  = 16
+  special = false
+}
+
+# Create the proxy EC2 instance inside the public subnet
+resource "aws_instance" "proxy_machine" {
+  ami               = data.aws_ami.rhel9.id
+  instance_type     = "t3.micro"
+  key_name          = aws_key_pair.proxy_machine_key.key_name # SSH key for debugging
+  availability_zone = var.availability_zone
+  tags              = { Name = "${var.name_prefix}-proxy-machine" }
+
+  user_data = templatefile(
+    "assets/userdata.yaml.tpl",
+    {
+      mitmproxy_sysctl_b64  = filebase64("assets/mitmproxy-sysctl.conf")
+      mitmproxy_service_b64 = filebase64("assets/mitmproxy.service")
+      caddyfile_b64 = base64encode(templatefile(
+        "assets/Caddyfile.tpl",
+        {
+          proxy_webui_password_hash = random_password.proxy_webui_password.bcrypt_hash
+          proxy_webui_username      = var.proxy_webui_username
+        }
+      ))
+    }
+  )
+  user_data_replace_on_change = true # Destroy and re-create this instance if user-data.yaml changes
+
+  subnet_id                   = aws_subnet.public.id
+  vpc_security_group_ids      = [aws_security_group.proxy_machine_sg.id]
+  associate_public_ip_address = true  # Necessary b/c we're not using a NAT gateway
+  source_dest_check           = false # Critical for correct routing
+}
+
+# Create a proxied subnet (where the test/"captive" machines will live)
+resource "aws_subnet" "proxied" {
+  vpc_id            = aws_vpc.main.id
+  availability_zone = var.availability_zone
+  cidr_block        = var.proxied_subnet_cidr_block
+  tags              = { Name = "${var.name_prefix}-proxied" }
+}
+
+# Create a route table for the proxied subnet that routes all traffic into the proxy_machine
+resource "aws_route_table" "proxied" {
+  vpc_id = aws_vpc.main.id
+  tags   = { Name = "${var.name_prefix}-proxied-rtb" }
+
+  route {
+    cidr_block           = "0.0.0.0/0"
+    network_interface_id = aws_instance.proxy_machine.primary_network_interface_id
+  }
+}
+
+# Associate the proxied subnet with its route table
+resource "aws_route_table_association" "proxied" {
+  subnet_id      = aws_subnet.proxied.id      # ID of proxied subnet
+  route_table_id = aws_route_table.proxied.id # ID of proxied route table
+}
+
+## OUTPUTS
+output "region" {
+  description = "VPC region"
+  value       = data.aws_region.current.name
+}
+output "proxy_machine_instance_id" {
+  description = "Proxy machine instance ID"
+  value       = aws_instance.proxy_machine.id
+}
+output "proxy_machine_ssh_url" {
+  description = "SSH URL for logging into the proxy machine"
+  value       = "ssh://ec2-user@${aws_instance.proxy_machine.public_ip}"
+}
+output "proxy_webui_url" {
+  description = "URL for accessing the proxy webUI (available in 2-5 minutes)"
+  value       = "https://${aws_instance.proxy_machine.public_ip}:8443/"
+}
+output "proxy_webui_username" {
+  description = "Proxy webUI username"
+  value       = var.proxy_webui_username
+}
+output "proxy_webui_password" {
+  description = "Proxy webUI password"
+  value       = random_password.proxy_webui_password.result
+  sensitive   = true
+}
+output "proxy_machine_cert_url" {
+  description = "Credentialed URL for downloading the proxy CA cert (available in 2-5 minutes)"
+  value       = "https://${var.proxy_webui_username}:${random_password.proxy_webui_password.result}@${aws_instance.proxy_machine.public_ip}:8443/mitmproxy-ca-cert.pem"
+  sensitive   = true
+}
+output "proxied_subnet_id" {
+  description = "Proxied subnet ID (launch your test/'captive' instances here)"
+  value       = aws_subnet.proxied.id
+}
+# output "public_subnet_id" {
+#   description = "The ID of the Public Subnet"
+#   value       = aws_subnet.public.id
+# }
+
+## DATA
+# Get the current AWS region
+data "aws_region" "current" {}
+
+# Automatic lookup of the latest official RHEL 9 AMI
+data "aws_ami" "rhel9" {
+  most_recent = true
+
+  filter {
+    name   = "platform-details"
+    values = ["Red Hat Enterprise Linux"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+
+  filter {
+    name   = "root-device-type"
+    values = ["ebs"]
+  }
+
+  filter {
+    name   = "manifest-location"
+    values = ["amazon/RHEL-9.*_HVM-*-x86_64-*-Hourly2-GP2"]
+  }
+
+  owners = ["309956199498"] # Amazon's "Official Red Hat" account
+}

--- a/examples/aws/terraform/vpc-proxied-transparent/terraform.tfvars.example
+++ b/examples/aws/terraform/vpc-proxied-transparent/terraform.tfvars.example
@@ -1,0 +1,37 @@
+## Sample Variables 
+## Fill in the values below and rename me to "terraform.tfvars" 
+
+# Your AWS Profile
+# This profile should be configured in your AWS credentials file, typically located at ~/.aws/credentials on Unix-based systems and C:\Users\USERNAME\.aws\credentials on Windows. 
+# The profile configuration should look something like this:
+# 
+# [default]
+# aws_access_key_id = YOUR_ACCESS_KEY
+# aws_secret_access_key = YOUR_SECRET_KEY
+#
+profile = "default"
+
+# The AWS region where you want to create your resources
+region = "us-east-1"
+
+# The availability zone within the region where you want to create your subnets
+availability_zone = "us-east-1a"
+
+# The CIDR block for your VPC
+vpc_cidr_block = "10.0.0.0/16"
+
+# The CIDR block for your public subnet within your VPC
+public_subnet_cidr_block = "10.0.0.0/24"
+
+# The CIDR block for your proxied subnet within your VPC
+proxied_subnet_cidr_block = "10.0.1.0/24"
+
+# A prefix to add to the Name tag associated with most of the resources created by these scripts
+name_prefix = "transparent-proxy"
+
+# SSH public key to use for ec2-user@proxy-machine
+proxy_machine_ssh_pubkey = "ssh-rsa AAAAB3N...SrbX8ZbabVohBK41 replaceme@example.com"
+
+# A CIDR block containing your workstation's IP, for SSH/webUI access to the proxy machine for debugging. 
+# Running "echo $(curl -s ipv4.icanhazip.com)/32' should produce a sane default value
+developer_cidr_block = "123.123.123.123/32"

--- a/examples/aws/terraform/vpc-proxied-transparent/variables.tf
+++ b/examples/aws/terraform/vpc-proxied-transparent/variables.tf
@@ -1,0 +1,68 @@
+# AWS Profile to use
+variable "profile" {
+  description = "AWS Profile to use"
+  type        = string
+  default     = "default"
+}
+
+# The AWS Region where resources will be created
+variable "region" {
+  description = "AWS Region"
+  type        = string
+  default     = "us-east-1" # Default to US East (N. Virginia)
+}
+
+# The availability zone where the subnets will be created
+variable "availability_zone" {
+  description = "The availability zone where the subnets will be created"
+  type        = string
+  default     = "us-east-1a" # Default to US East (N. Virginia) AZ a
+}
+
+# CIDR block for the VPC
+variable "vpc_cidr_block" {
+  description = "CIDR block for the VPC"
+  type        = string
+  default     = "10.0.0.0/16" # Default to a /16 block within the 10.0.0.0 private network
+}
+
+# CIDR block for the public subnet
+variable "public_subnet_cidr_block" {
+  description = "CIDR block for the public subnet"
+  type        = string
+  default     = "10.0.0.0/24" # Default to a /24 block within the 10.0.0.0 private network
+}
+
+# CIDR block for the private subnet
+variable "proxied_subnet_cidr_block" {
+  description = "CIDR block for the private subnet"
+  type        = string
+  default     = "10.0.1.0/24" # Default to a /24 block within the 10.0.0.0 private network
+}
+
+# User/developer's CIDR block for SSH/webUI access to the proxy machine for debugging
+variable "developer_cidr_block" {
+  description = "A CIDR block containing your workstation's IP, for SSH/webUI access to the proxy machine for debugging. The output of 'echo $(curl -s ipv4.icanhazip.com)/32' is a sane default"
+  type        = string
+}
+
+# Username to use for the proxy machine web UI
+variable "proxy_webui_username" {
+  description = "Username to use for the proxy machine web UI"
+  type        = string
+  default     = "developer"
+}
+
+# Prefix to add to name tags
+variable "name_prefix" {
+  description = "prefix to add to the Name tag associated with most of the resources created by these scripts"
+  type        = string
+  default     = "transparent-proxy-"
+}
+
+# SSH public key to use for ec2-user@proxy-machine
+variable "proxy_machine_ssh_pubkey" {
+  description = "SSH public key to use for ec2-user@proxy-machine"
+  type        = string
+}
+


### PR DESCRIPTION
<!-- Type of change
Please mark this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement/Feature
- Refactoring
- Tests
- Configuration
- Docs
-->

## What does this PR do?
This PR supersedes #267 and implements [OSD-23854](https://issues.redhat.com/browse/OSD-23854), which calls for the code from [abyrne55/transparent-proxy-setup](https://github.com/abyrne55/transparent-proxy-setup) to be moved into this repo's "example" code directory. The two directories created by this PR (vpc-proxied-explicit and vpc-proxied-transparent) contain Terraform scripts for quickly deploying AWS VPCs that explicitly- or transparently-proxy their traffic through a generated proxy server. 

## Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have tested the functionality against gcp / aws, it doesn't cause any regression~~
- [ ] I have added execution results to the PR's readme

## How to test this PR locally
Please read through and run through the two READMEs included in this PR