### PR TITLE
Sync OWNERS with Team Aurora roster

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,5 +1,4 @@
 reviewers:
-  - AlexVulaj
   - abyrne55
   - reedcort
   - dakotalongRH
@@ -9,12 +8,13 @@ approvers:
   - abyrne55
   - rafael-azevedo
   - fahlmant
-  - AlexVulaj
+  - luis-falcon
 emeritus_approvers:
   - bng0y
   - boranx
   - bdematte
   - mjlshen
+  - AlexVulaj
 maintainers:
   - abyrne55
   - fahlmant


### PR DESCRIPTION
This PR updates OWNERS such that it aligns with the recent Team Aurora roster changes. I've moved approvers no longer involved with the project to [emeritus_approvers](https://www.kubernetes.dev/docs/guide/owners/#emeritus). I also added Luis as an approver to ensure we have at least two approvers from Team Aurora.

Open to feedback 😃