### PR TITLE
Clarify cleanup fallback warning message

### DIFF
--- a/pkg/verifier/aws/entry_point.go
+++ b/pkg/verifier/aws/entry_point.go
@@ -297,7 +297,7 @@ func (a *AwsVerifier) ValidateEgress(vei verifier.ValidateEgressInput) *output.O
 			})
 			if err != nil {
 				a.Logger.Info(vei.Ctx, "Unable to detach instance from security group. Falling back to slower cloud resource cleanup method.")
-				a.writeDebugLogs(vei.Ctx, fmt.Sprintf("Error encountered while trying to detach instance: %s.", err))
+				a.writeDebugLogs(vei.Ctx, fmt.Sprintf("Fell back to slower cloud resource cleanup because faster method (network interface detatchment) blocked by AWS: %s.", err))
 			}
 		}
 


### PR DESCRIPTION
This PR addresses [OSD-25048](https://issues.redhat.com/browse/OSD-25048), which identified confusion arising from the warning printed when a slower cloud resource cleanup method must be used. This PR simply changes the wording of that message to be less alarming.