### PR TITLE
OSD-25868: Adds `aws-hosted-cp` as a valid Platform name

### DIFF
--- a/pkg/data/cloud/platform.go
+++ b/pkg/data/cloud/platform.go
@@ -8,25 +8,25 @@ import (
 
 // Platform type represents specific Platform types and how they map to their respective platforms.
 type Platform struct {
-	// names holds 2 unique lowercase names of the Platform (e.g., "aws"). We use a fixed-
-	// size array so that this struct remains comparable. Any of the 2 values can be used to refer
+	// names holds 3 unique lowercase names of the Platform (e.g., "aws"). We use a fixed-
+	// size array so that this struct remains comparable. Any of the 3 values can be used to refer
 	// to this specific Platform via Platform.ByName(), but only the first (element
 	// 0) element will be the "preferred name" returned by Platform.String()
-	names [2]string
+	names [3]string
 }
 
 var (
 	AWSClassic = Platform{
-		names: [2]string{"aws-classic", "aws"},
+		names: [3]string{"aws-classic", "aws"},
 	}
 	AWSHCP = Platform{
-		names: [2]string{"aws-hcp", "hostedcluster"},
+		names: [3]string{"aws-hcp", "aws-hosted-cp", "hostedcluster"},
 	}
 	AWSHCPZeroEgress = Platform{
-		names: [2]string{"aws-hcp-zeroegress"},
+		names: [3]string{"aws-hcp-zeroegress"},
 	}
 	GCPClassic = Platform{
-		names: [2]string{"gcp-classic", "gcp"},
+		names: [3]string{"gcp-classic", "gcp"},
 	}
 )
 

--- a/pkg/data/cloud/platform.go
+++ b/pkg/data/cloud/platform.go
@@ -40,6 +40,11 @@ func (plat Platform) String() string {
 // platform if the provided name isn't supported
 func ByName(name string) (Platform, error) {
 	normalizedName := strings.TrimSpace(strings.ToLower(name))
+
+	if normalizedName == "" {
+		return Platform{}, fmt.Errorf("attempted to lookup Platform with empty string")
+	}
+
 	if slices.Contains(AWSClassic.names[:], normalizedName) {
 		return AWSClassic, nil
 	}

--- a/pkg/data/cloud/platform_test.go
+++ b/pkg/data/cloud/platform_test.go
@@ -143,6 +143,10 @@ func TestByName(t *testing.T) {
 			name: "invalid name",
 			want: Platform{},
 		},
+		{
+			name: "",
+			want: Platform{},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/data/cloud/platform_test.go
+++ b/pkg/data/cloud/platform_test.go
@@ -59,7 +59,7 @@ func TestPlatform_String(t *testing.T) {
 
 func TestPlatform_IsValid(t *testing.T) {
 	type fields struct {
-		names [2]string
+		names [3]string
 	}
 	tests := []struct {
 		name   string
@@ -84,7 +84,7 @@ func TestPlatform_IsValid(t *testing.T) {
 		{
 			name: "fake platform",
 			fields: fields{
-				names: [2]string{"foo", "bar"},
+				names: [3]string{"foo", "bar"},
 			},
 			want: false,
 		},
@@ -121,6 +121,10 @@ func TestByName(t *testing.T) {
 		},
 		{
 			name: "aws-hcp",
+			want: AWSHCP,
+		},
+		{
+			name: "aws-hosted-cp",
 			want: AWSHCP,
 		},
 		{


### PR DESCRIPTION
<!-- Type of change
Please mark this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement/Feature
- Refactoring
- Tests
- Configuration
- Docs
-->

## What does this PR do? / Related Issues / Jira

This extends the Platform structs to accept `aws-hosted-cp` as a valid value for looking up AWSHCP `ByName()`. This value is used internally still and blocks integrating the updated verifier.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have tested the functionality against gcp / aws, it doesn't cause any regression
- [ ] I have added execution results to the PR's readme

## Reviewer's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] (This needs to be done after technical review) I've run the branch on my local, verified that the functionality is ok

## How to test this PR locally / Special Instructions

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Logs 

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
