### PR TITLE
Add optional 'escape routes' to proxied VPC terraform examples

### DIFF
--- a/examples/aws/terraform/vpc-proxied-explicit/README.md
+++ b/examples/aws/terraform/vpc-proxied-explicit/README.md
@@ -8,7 +8,7 @@ The Terraform scripts in this directory will deploy an AWS VPC with a [mitmproxy
 ## Setup
 
 > [!IMPORTANT]  
-> The proxied subnet set up by this script will be configured to allow only HTTP[S] (i.e., TCP ports 80 & 443) egress via the generated proxy server. IOW, **anything you launch in the proxied subnet will not be able to connect to the internet unless the application is configured to use the proxy server**. Same goes for any application using ports other than 80 or 443 (e.g., Splunk inputs). If this behavior doesn't work for you, you'll need to add an internet gateway or NAT gateway to the proxied subnet and adjust its routing table accordingly.
+> The proxied subnet set up by this script will be configured to allow only HTTP[S] (i.e., TCP ports 80 & 443) egress via the generated proxy server. IOW, **anything you launch in the proxied subnet will not be able to connect to the internet unless the application is configured to use the proxy server**. Same goes for any application using ports other than 80 or 443 (e.g., Splunk inputs). You can partially bypass this behavior by adding CIDR blocks covering the destination IPs you'd like to access unproxied to `proxied_subnet_escape_routes` in your terraform.tfvars, which will add a NAT gateway to the proxied subnet and adjust its routing table accordingly.
 
 1. Clone this repo and `cd` into this directory
 2. Run `terraform init`

--- a/examples/aws/terraform/vpc-proxied-explicit/terraform.tfvars.example
+++ b/examples/aws/terraform/vpc-proxied-explicit/terraform.tfvars.example
@@ -26,8 +26,17 @@ public_subnet_cidr_block = "10.0.0.0/24"
 # The CIDR block for your proxied subnet within your VPC
 proxied_subnet_cidr_block = "10.0.1.0/24"
 
+# (optional) A list of CIDR blocks for which you'd like to create "proxy escape routes", 
+# i.e., routes that allow clients in your proxied subnet to connect to certain websites 
+# directly without going through the proxy (e.g., via NO_PROXY env var). If you're interested 
+# in NO_PROXY-ing a list of numbered domain names, for example, try using the following bash
+# one-liner to generate a list of CIDRs that cover all of the domain names
+# echo -n \[; for IP in $(dig +short $(seq -f"inputs%g.osdsecuritylogs.splunkcloud.com" -s" " 1 15) | sort -u); do echo -n "\"$IP/32\", "; done; echo -e "\b\b]"
+# You can also just allow all traffic to escape the proxy by setting this to ["0.0.0.0/0"].
+proxied_subnet_escape_routes = []
+
 # A prefix to add to the Name tag associated with most of the resources created by these scripts
-name_prefix = "transparent-proxy"
+name_prefix = "explicit-proxy"
 
 # SSH public key to use for ec2-user@proxy-machine
 proxy_machine_ssh_pubkey = "ssh-rsa AAAAB3N...SrbX8ZbabVohBK41 replaceme@example.com"

--- a/examples/aws/terraform/vpc-proxied-explicit/variables.tf
+++ b/examples/aws/terraform/vpc-proxied-explicit/variables.tf
@@ -35,9 +35,16 @@ variable "public_subnet_cidr_block" {
 
 # CIDR block for the private subnet
 variable "proxied_subnet_cidr_block" {
-  description = "CIDR block for the private subnet"
+  description = "CIDR block for the proxied subnet"
   type        = string
   default     = "10.0.1.0/24" # Default to a /24 block within the 10.0.0.0 private network
+}
+
+# Optional destination CIDR blocks for which proxy will be bypassed
+variable "proxied_subnet_escape_routes" {
+  description = "CIDR blocks that proxied clients can connect to directly"
+  type        = list(string)
+  default     = []
 }
 
 # User/developer's CIDR block for SSH/webUI access to the proxy machine for debugging

--- a/examples/aws/terraform/vpc-proxied-transparent/README.md
+++ b/examples/aws/terraform/vpc-proxied-transparent/README.md
@@ -11,7 +11,7 @@ The Terraform scripts in this directory will deploy an AWS VPC with a [mitmproxy
 ## Setup
 
 > [!IMPORTANT]  
-> The proxied subnet set up by this script will be configured to allow only HTTP[S] (i.e., TCP ports 80 & 443) egress via the generated proxy server. IOW, **anything you launch in the proxied subnet will not be able to connect to the internet via any ports other than TCP ports 80 or 443.** This behavior is enforced by the proxied subnet's routing table and proxy server's prerouting rules, and such routing is required to implement the "transparent" part of the proxy.
+> The proxied subnet set up by this script will be configured to allow only HTTP[S] (i.e., TCP ports 80 & 443) egress via the generated proxy server. IOW, **anything you launch in the proxied subnet will not be able to connect to the internet via any ports other than TCP ports 80 or 443.** This behavior is enforced by the proxied subnet's routing table and proxy server's prerouting rules, and such routing is required to implement the "transparent" part of the proxy. You can partially bypass this behavior by adding CIDR blocks covering the destination IPs you'd like to access unproxied to `proxied_subnet_escape_routes` in your terraform.tfvars, which will add a NAT gateway to the proxied subnet and adjust its routing table accordingly.
 
 1. Clone this repo and `cd` into this directory
 2. Run `terraform init`

--- a/examples/aws/terraform/vpc-proxied-transparent/main.tf
+++ b/examples/aws/terraform/vpc-proxied-transparent/main.tf
@@ -137,6 +137,21 @@ resource "aws_subnet" "proxied" {
   tags              = { Name = "${var.name_prefix}-proxied" }
 }
 
+# If any escape routes specified, create an unproxied NAT gateway
+resource "aws_eip" "escape_nat_eip" {
+  count      = min(1, length(var.proxied_subnet_escape_routes))
+  domain     = "vpc"
+  tags       = { Name = "${var.name_prefix}-escape-nat-eip" }
+  depends_on = [aws_internet_gateway.igw]
+}
+resource "aws_nat_gateway" "escape_nat_gw" {
+  count         = min(1, length(var.proxied_subnet_escape_routes))
+  allocation_id = aws_eip.escape_nat_eip[0].id
+  subnet_id     = aws_subnet.public.id
+  tags          = { Name = "${var.name_prefix}-escape-nat-gw" }
+  depends_on    = [aws_internet_gateway.igw]
+}
+
 # Create a route table for the proxied subnet that routes all traffic into the proxy_machine
 resource "aws_route_table" "proxied" {
   vpc_id = aws_vpc.main.id
@@ -145,6 +160,13 @@ resource "aws_route_table" "proxied" {
   route {
     cidr_block           = "0.0.0.0/0"
     network_interface_id = aws_instance.proxy_machine.primary_network_interface_id
+  }
+  dynamic "route" {
+    for_each = toset(var.proxied_subnet_escape_routes)
+    content {
+      cidr_block = route.value
+      gateway_id = aws_nat_gateway.escape_nat_gw[0].id
+    }
   }
 }
 

--- a/examples/aws/terraform/vpc-proxied-transparent/terraform.tfvars.example
+++ b/examples/aws/terraform/vpc-proxied-transparent/terraform.tfvars.example
@@ -26,6 +26,14 @@ public_subnet_cidr_block = "10.0.0.0/24"
 # The CIDR block for your proxied subnet within your VPC
 proxied_subnet_cidr_block = "10.0.1.0/24"
 
+# (optional) A list of CIDR blocks for which you'd like to create "proxy escape routes", 
+# i.e., routes that cause clients in your proxied subnet to connect to certain websites 
+# directly without going through the proxy. If you're interested in allowing direct connection
+# to a list of numbered domain names, for example, try using the following bash one-liner to 
+# generate a list of CIDRs that cover all of the domain names
+# echo -n \[; for IP in $(dig +short $(seq -f"inputs%g.osdsecuritylogs.splunkcloud.com" -s" " 1 15) | sort -u); do echo -n "\"$IP/32\", "; done; echo -e "\b\b]"
+proxied_subnet_escape_routes = []
+
 # A prefix to add to the Name tag associated with most of the resources created by these scripts
 name_prefix = "transparent-proxy"
 

--- a/examples/aws/terraform/vpc-proxied-transparent/variables.tf
+++ b/examples/aws/terraform/vpc-proxied-transparent/variables.tf
@@ -33,11 +33,18 @@ variable "public_subnet_cidr_block" {
   default     = "10.0.0.0/24" # Default to a /24 block within the 10.0.0.0 private network
 }
 
-# CIDR block for the private subnet
+# CIDR block for the proxied subnet
 variable "proxied_subnet_cidr_block" {
-  description = "CIDR block for the private subnet"
+  description = "CIDR block for the proxied subnet"
   type        = string
   default     = "10.0.1.0/24" # Default to a /24 block within the 10.0.0.0 private network
+}
+
+# Optional destination CIDR blocks for which proxy will be bypassed
+variable "proxied_subnet_escape_routes" {
+  description = "CIDR blocks that proxied clients can connect to directly"
+  type        = list(string)
+  default     = []
 }
 
 # User/developer's CIDR block for SSH/webUI access to the proxy machine for debugging


### PR DESCRIPTION
This PR adds optional "escape routes" to the proxied VPC terraform scripts under `examples/aws/terraform/`. I used this to test the `--no-proxy` feature added in #280. 

## What does this PR do? / Related Issues / Jira

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have tested the functionality against gcp / aws, it doesn't cause any regression
- [ ] I have added execution results to the PR's readme

## Reviewer's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] (This needs to be done after technical review) I've run the branch on my local, verified that the functionality is ok

## How to test this PR locally / Special Instructions

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Logs 

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
