### PR TITLE
OSD-25966: Fix issue with `--egress-list-location` CLI flag

### DIFF
--- a/pkg/verifier/aws/entry_point.go
+++ b/pkg/verifier/aws/entry_point.go
@@ -131,26 +131,27 @@ func (a *AwsVerifier) ValidateEgress(vei verifier.ValidateEgressInput) *output.O
 	egressListYaml := vei.EgressListYaml
 	var egressListStr, tlsDisabledEgressListStr string
 	if egressListYaml == "" {
-		githubEgressList, githubListErr := egress_lists.GetGithubEgressList(vei.PlatformType)
-		if githubListErr == nil {
-			egressListYaml, githubListErr = githubEgressList.GetContent()
-			if githubListErr == nil {
-				a.Logger.Info(vei.Ctx, "Using egress URL list from %s at SHA %s", githubEgressList.GetURL(), githubEgressList.GetSHA())
-				egressListStr, tlsDisabledEgressListStr, githubListErr = egress_lists.EgressListToString(egressListYaml, map[string]string{"AWS_REGION": a.AwsClient.Region})
-			}
-		}
+		githubEgressList, err := egress_lists.GetGithubEgressList(vei.PlatformType)
+		if err != nil {
+			a.Logger.Error(vei.Ctx, "Failed to get egress list from GitHub, falling back to local list: %v", err)
 
-		if githubListErr != nil {
-			a.Logger.Error(vei.Ctx, "Failed to get egress list from GitHub, falling back to local list: %v", githubListErr)
 			egressListYaml, err = egress_lists.GetLocalEgressList(vei.PlatformType)
 			if err != nil {
 				return a.Output.AddError(err)
 			}
-			egressListStr, tlsDisabledEgressListStr, err = egress_lists.EgressListToString(egressListYaml, map[string]string{"AWS_REGION": a.AwsClient.Region})
+		} else {
+			egressListYaml, err = githubEgressList.GetContent()
 			if err != nil {
 				return a.Output.AddError(err)
 			}
+
+			a.Logger.Info(vei.Ctx, "Using egress URL list from %s at SHA %s", githubEgressList.GetURL(), githubEgressList.GetSHA())
 		}
+	}
+
+	egressListStr, tlsDisabledEgressListStr, err = egress_lists.EgressListToString(egressListYaml, map[string]string{"AWS_REGION": a.AwsClient.Region})
+	if err != nil {
+		return a.Output.AddError(err)
 	}
 
 	// Generate the userData file


### PR DESCRIPTION
<!-- Type of change
Please mark this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement/Feature
- Refactoring
- Tests
- Configuration
- Docs
-->

## What does this PR do? / Related Issues / Jira

The `--egress-list-location` flag provided by the CLI was being ignored in the parsing logic that constructs URLS from given input YAML. This primarily ensures that if the `ValidateEgressInput` has a populated `EgressListYaml` value, we parse it and use it. I also moved the flow control around a bit for the decision making about where to source the data from to make it a bit easier to follow.

I wanted to refactor this further and consolidate the behavior between both AWS and GCP, but opted to tackle that in a follow on so it was easier to review the bug in isolation.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have tested the functionality against gcp / aws, it doesn't cause any regression
- [x] I have added execution results to the PR's readme

## Reviewer's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] (This needs to be done after technical review) I've run the branch on my local, verified that the functionality is ok

## How to test this PR locally / Special Instructions

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

I ran this locally with the CLI to confirm it works with and without an `--egress-list-location` flag:

**With**
```
> ./osd-network-verifier egress --profile devaccount --subnet-id subnet-0bab965a3722b750d --no-proxy google.com --region us-west-2 --debug --egress-list-location=https://raw.githubusercontent.com/openshift/osd-network-verifier/refs/heads/main/pkg/data/egress_lists/aws-classic.yaml
Using region: us-west-2
Using external egress list from https://raw.githubusercontent.com/openshift/osd-network-verifier/refs/heads/main/pkg/data/egress_lists/aws-classic.yaml
```

**Without**
```
> ./osd-network-verifier egress --profile devaccount --subnet-id subnet-0bab965a3722b750d --no-proxy google.com --region us-west-2 --debug
Using region: us-west-2
configured a 5s timeout for each egress request
defaulted to x86 CPU architecture
defaulted to instance type t3.micro
defaulted to machine image ami-042d4c3472784287c
Using egress URL list from https://api.github.com/repos/openshift/osd-network-verifier/contents/pkg/data/egress_lists/aws-classic.yaml?ref=main at SHA c31b52add1381fa61e5c0446370c608e68feeb58
```

## Logs 

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
