### PR TITLE
OSD-26102 added architechturebyname check

### DIFF
--- a/cmd/egress/cmd.go
+++ b/cmd/egress/cmd.go
@@ -90,23 +90,16 @@ are set correctly before execution.
 				config.region = getDefaultRegion(platformType)
 			}
 
-			// Set Up Proxy
-			if config.noTls && config.CaCert != "" {
-				fmt.Println("--cacert value will be ignored since --no-tls was passed")
-			}
-
-			if !config.noTls {
-				if config.CaCert != "" {
-					// Read in the cert file
-					cert, err := os.ReadFile(config.CaCert)
-					if err != nil {
-						fmt.Println(err)
-						os.Exit(1)
-					}
-					// store string form of it
-					// this was agreed with sda that they'll be communicating it as a string.
-					config.CaCert = bytes.NewBuffer(cert).String()
+			if config.CaCert != "" {
+				// Read in the cert file
+				cert, err := os.ReadFile(config.CaCert)
+				if err != nil {
+					fmt.Println(err)
+					os.Exit(1)
 				}
+				// store string form of it
+				// this was agreed with sda that they'll be communicating it as a string.
+				config.CaCert = bytes.NewBuffer(cert).String()
 			}
 
 			p := proxy.ProxyConfig{
@@ -275,6 +268,7 @@ are set correctly before execution.
 		validateEgressCmd.PrintErr(err)
 	}
 
+	validateEgressCmd.MarkFlagsMutuallyExclusive("cacert", "no-tls")
 	return validateEgressCmd
 }
 

--- a/pkg/data/cpu/cpu.go
+++ b/pkg/data/cpu/cpu.go
@@ -83,6 +83,11 @@ func (arch Architecture) IsValid() bool {
 // architecture if the provided name isn't supported
 func ArchitectureByName(name string) Architecture {
 	normalizedName := strings.TrimSpace(strings.ToLower(name))
+
+	if normalizedName == "" {
+		return Architecture{}
+	}
+
 	if slices.Contains(ArchX86.names[:], normalizedName) {
 		return ArchX86
 	}


### PR DESCRIPTION
added ArchitechtureByName() function check after normalization in order to account for an architecture with less than 3 names in the future. Also added better --notls and --cacert flags as mutually exclusive


- Bug
- Enhancement