### PR TITLE
osd-21895 network verifier highlights kms permission issues

### DIFF
--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -13,6 +13,10 @@ type GenericError struct {
 	message   string
 }
 
+type KmsError struct {
+	message string
+}
+
 func (e *GenericError) Error() string {
 	return e.message
 }
@@ -21,8 +25,13 @@ func (e *GenericError) EgressURL() string {
 	return e.egressURL
 }
 
+func (k *KmsError) Error() string {
+	return k.message
+}
+
 // Ensure GenericError implements the error interface
 var _ error = &GenericError{}
+var _ error = &KmsError{}
 
 // NewGenericError does some preprocessing if the provided error contains an aws-sdk-go-v2 error, otherwise just
 // prepends `network verifier error: `
@@ -59,5 +68,11 @@ func NewEgressURLError(url string) error {
 	return &GenericError{
 		egressURL: url,
 		message:   fmt.Sprintf("egressURL error: %s", url),
+	}
+}
+
+func NewKmsError(msg string) error {
+	return &KmsError{
+		message: msg,
 	}
 }

--- a/pkg/verifier/aws/aws_verifier.go
+++ b/pkg/verifier/aws/aws_verifier.go
@@ -71,7 +71,7 @@ const (
 	networkValidatorRepo  = "quay.io/app-sre/osd-network-verifier"
 	userdataEndVerifier   = "USERDATA END"
 	prepulledImageMessage = "Warning: could not pull the specified docker image, will try to use the prepulled one"
-	invalildKMSCode       = "Client.InvalidKMSKey.InvalidState"
+	invalidKMSCode       = "Client.InvalidKMSKey.InvalidState"
 )
 
 // AwsVerifier holds an aws client and knows how to fulfill the VerifierService which contains all functions needed for verifier
@@ -353,7 +353,7 @@ func (a *AwsVerifier) createEC2Instance(input createEC2InstanceInput) (string, e
 		}
 
 		waiterErr := fmt.Errorf("%s: terminated %s after timing out waiting for instance to be running", err, instanceID)
-		if stateCode == invalildKMSCode {
+		if stateCode == invalidKMSCode {
 			waiterErr = handledErrors.NewKmsError("encountered issue accessing KMS key when launching instance.")
 		}
 

--- a/pkg/verifier/aws/aws_verifier.go
+++ b/pkg/verifier/aws/aws_verifier.go
@@ -71,7 +71,7 @@ const (
 	networkValidatorRepo  = "quay.io/app-sre/osd-network-verifier"
 	userdataEndVerifier   = "USERDATA END"
 	prepulledImageMessage = "Warning: could not pull the specified docker image, will try to use the prepulled one"
-	invalidKMSCode       = "Client.InvalidKMSKey.InvalidState"
+	invalidKMSCode        = "Client.InvalidKMSKey.InvalidState"
 )
 
 // AwsVerifier holds an aws client and knows how to fulfill the VerifierService which contains all functions needed for verifier


### PR DESCRIPTION
Added code to allow network verifier to highlight issues when instance changes state to termination due to issues with KMS

- Enhancement/Feature


## What does this PR do? / Related Issues / Jira
Solves https://issues.redhat.com/browse/OSD-21895

