### PR TITLE
OSD-26236 leaver process member removal

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -15,7 +15,6 @@ emeritus_approvers:
   - bng0y
   - boranx
   - bdematte
-  - mjlshen
 maintainers:
   - abyrne55
   - fahlmant


### PR DESCRIPTION
Removing michael shen from OWNER FILE as part of the leaver process