### PR TITLE
Remove servicequota URL from aws-classic.yaml

### DIFF
--- a/pkg/data/egress_lists/aws-classic.yaml
+++ b/pkg/data/egress_lists/aws-classic.yaml
@@ -168,6 +168,3 @@ endpoints:
   - host: tagging.${AWS_REGION}.amazonaws.com
     ports:
       - 443
-  - host: servicequotas.${AWS_REGION}.amazonaws.com
-    ports:
-      - 443

--- a/pkg/data/egress_lists/egress_lists_test.go
+++ b/pkg/data/egress_lists/egress_lists_test.go
@@ -69,7 +69,7 @@ func Test_GenerateEgressListsWithoutInput_WhenGitHubFails(t *testing.T) {
 	}
 
 	// In this case we are falling back to the local file, so assert an arbitrary URL we know
-	expected := "https://servicequotas.us-east-1.amazonaws.com:443"
+	expected := "https://console.redhat.com:443"
 	if !strings.Contains(tls, expected) {
 		t.Errorf("expected string to contain %s, got: %s", expected, tls)
 	}


### PR DESCRIPTION
This PR removed the servicequota.$REGION.amazonaws.com URL from the OSD/ROSA Classic egress URL list, as that URL has been deemed unnecessary and is about to be removed from the docs (see openshift/openshift-docs#77271)