### PR TITLE
Properly set proxy env vars in systemd curl probe

### DIFF
--- a/pkg/probes/curl/systemd-template.sh
+++ b/pkg/probes/curl/systemd-template.sh
@@ -49,6 +49,7 @@ Type=oneshot
 ExecStart=/usr/bin/curl.sh
 Restart=on-failure
 RemainAfterExit=true
+Environment="http_proxy=${HTTP_PROXY}" "https_proxy=${HTTPS_PROXY}" "no_proxy=${NO_PROXY}"
 [Install]
 WantedBy=multi-user.target
 EOF
@@ -74,8 +75,7 @@ EOF
 echo "${CACERT}" | base64 > /proxy.pem
 chmod 0755 /proxy.pem
 
-# set proxy environment variables, make script executable and start systemd services 
-export http_proxy=${HTTP_PROXY} https_proxy=${HTTPS_PROXY} no_proxy="${NO_PROXY}"
+# make script executable and start systemd services 
 chmod 777 /usr/bin/curl.sh /usr/bin/terminate.sh
 systemctl daemon-reload
 systemctl start silence


### PR DESCRIPTION
This PR fixes OSD-27707, which identified a bug in how we were passing the `http_proxy` and related environmental variables to the systemd-based curl probe. Using the `Environment` systemd directive ensures the variables are properly set