### PR TITLE
Consolidate the default timeout, lint

### DIFF
--- a/pkg/verifier/aws/aws_verifier_test.go
+++ b/pkg/verifier/aws/aws_verifier_test.go
@@ -93,7 +93,7 @@ func TestFindUnreachableEndpointsWithCurlProbe(t *testing.T) {
 			}
 
 			if tt.expectSuccess != cli.Output.IsSuccessful() {
-				t.Errorf(tt.errorMessage)
+				t.Error(tt.errorMessage)
 			}
 		})
 	}

--- a/pkg/verifier/aws/entry_point.go
+++ b/pkg/verifier/aws/entry_point.go
@@ -3,13 +3,11 @@ package awsverifier
 import (
 	"encoding/base64"
 	"fmt"
-	"os"
-	"strconv"
-	"time"
-
 	awsTools "github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2Types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"os"
+	"strconv"
 
 	"github.com/openshift/osd-network-verifier/pkg/data/cloud"
 
@@ -45,7 +43,7 @@ func (a *AwsVerifier) ValidateEgress(vei verifier.ValidateEgressInput) *output.O
 
 	// Default to 5sec per-request timeout if none specified
 	if vei.Timeout <= 0 {
-		vei.Timeout = 5 * time.Second
+		vei.Timeout = verifier.DefaultTimeout
 	}
 	a.writeDebugLogs(vei.Ctx, fmt.Sprintf("configured a %s timeout for each egress request", vei.Timeout))
 

--- a/pkg/verifier/gcp/entry_point.go
+++ b/pkg/verifier/gcp/entry_point.go
@@ -3,20 +3,14 @@ package gcpverifier
 import (
 	"encoding/base64"
 	"fmt"
-	"github.com/openshift/osd-network-verifier/pkg/helpers"
-	"strconv"
-	"time"
-
 	"github.com/openshift/osd-network-verifier/pkg/data/cloud"
 	"github.com/openshift/osd-network-verifier/pkg/data/cpu"
 	"github.com/openshift/osd-network-verifier/pkg/data/egress_lists"
+	"github.com/openshift/osd-network-verifier/pkg/helpers"
 	"github.com/openshift/osd-network-verifier/pkg/output"
 	"github.com/openshift/osd-network-verifier/pkg/probes/curl"
 	"github.com/openshift/osd-network-verifier/pkg/verifier"
-)
-
-const (
-	DefaultTimeout = 5 * time.Second
+	"strconv"
 )
 
 // ValidateEgress performs validation process for egress
@@ -43,7 +37,7 @@ func (g *GcpVerifier) ValidateEgress(vei verifier.ValidateEgressInput) *output.O
 
 	// Set timeout to default if not specified
 	if vei.Timeout <= 0 {
-		vei.Timeout = DefaultTimeout
+		vei.Timeout = verifier.DefaultTimeout
 	}
 	g.Logger.Debug(vei.Ctx, "configured a %s timeout for each egress request", vei.Timeout)
 

--- a/pkg/verifier/gcp/gcp_verifier.go
+++ b/pkg/verifier/gcp/gcp_verifier.go
@@ -234,7 +234,7 @@ func (g *GcpVerifier) describeComputeServiceInstances(projectID, zone, instanceN
 
 	case "STOPPING", "STOPPED", "TERMINATED", "SUSPENDED":
 		g.Logger.Debug(context.TODO(), "Fatal - Instance status: ", instanceName)
-		return "FATAL", fmt.Errorf(resp.Status)
+		return "FATAL", fmt.Errorf("instance is in state '%s'", resp.Status)
 	}
 
 	if len(resp.Status) == 0 {

--- a/pkg/verifier/package_verifier.go
+++ b/pkg/verifier/package_verifier.go
@@ -11,6 +11,8 @@ import (
 	"github.com/openshift/osd-network-verifier/pkg/proxy"
 )
 
+const DefaultTimeout = 5 * time.Second
+
 // VerifierService defines the behaviors necessary to run verifier completely.
 // Any clients that fulfill this interface will be able to run all verifier tests
 type verifierService interface {


### PR DESCRIPTION
<!-- Type of change
Please mark this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement/Feature
- Refactoring
- Tests
- Configuration
- Docs
-->

## What does this PR do? / Related Issues / Jira
This consolidates the default timeout into a shared constant. I noticed these were set individually when checking on what it was.

Also fixed a couple linting failures, which means I need to figure out why these aren't caught/showing up in CI..

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have tested the functionality against gcp / aws, it doesn't cause any regression
- [ ] I have added execution results to the PR's readme

## Reviewer's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] (This needs to be done after technical review) I've run the branch on my local, verified that the functionality is ok

## How to test this PR locally / Special Instructions

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Logs 

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
