### PR TITLE
OSD-29370: Utilize `GOENV` in local Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,9 @@ LDFLAGS=-ldflags="-X '$(PREFIX).Version=$(VERSION)' -X '$(PREFIX).CommitHash=$(C
 
 .PHONY: build
 build:
-	go fmt ./...
-	go mod tidy
-	go build $(LDFLAGS) $(GOFLAGS) .
+	${GOENV} go fmt ./...
+	${GOENV} go mod tidy
+	${GOENV} go build $(LDFLAGS) $(GOFLAGS) .
 
 .PHONY: fmt
 fmt:
@@ -28,7 +28,7 @@ check-fmt: fmt
 
 .PHONY: test
 test:
-	go test $(GOFLAGS) ./...
+	${GOENV} go test $(GOFLAGS) ./...
 
 .PHONY: boilerplate-update
 boilerplate-update:


### PR DESCRIPTION
## What does this PR do? / Related Issues / Jira

As part of adopting boilerplate here fully, we now need to set `GOENV` to pull that value from the boilerplate makefiles. This ensures things like a custom `GOCACHE` value are honored.

TBD if https://github.com/openshift/boilerplate/pull/526 lands. If so, I will come back and remove this.

Blocks https://github.com/openshift/release/pull/63965

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have tested the functionality against gcp / aws, it doesn't cause any regression
- [ ] I have added execution results to the PR's readme

## Reviewer's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] (This needs to be done after technical review) I've run the branch on my local, verified that the functionality is ok

## How to test this PR locally / Special Instructions

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Logs 

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
