### PR TITLE
SREP-597: Export curl command building to another package

### DIFF
--- a/pkg/data/curlgen/curlgen.go
+++ b/pkg/data/curlgen/curlgen.go
@@ -1,0 +1,57 @@
+package curlgen
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// Options struct contains flag options that will be used to build
+// the curl command. Every Option directly maps to a flag that can
+// be used to configure your curl command.
+type Options struct {
+	CaPath          string
+	ProxyCaPath     string
+	Retry           int
+	MaxTime         string
+	NoTls           string
+	Urls            string
+	TlsDisabledUrls string
+}
+
+// GenerateString function will be used to transform the Configurations (options)
+// used to built the Options struct and build a full Curl command and return it as a string
+func GenerateString(cfg *Options, outputLinePrefix string) (string, error) {
+	command := fmt.Sprintf(`curl --capath %s --proxy-capath %s --retry %v --retry-connrefused -t B -Z -s -I -m %s -w "%%{stderr}%s%%{json}\n"`,
+		cfg.CaPath,
+		cfg.ProxyCaPath,
+		cfg.Retry,
+		cfg.MaxTime,
+		outputLinePrefix,
+	)
+
+	if cfg.NoTLS() {
+		command += " --insecure"
+		// In addition to adding the curl flag, we can merge the list of "tlsDisabled" URLs
+		// with the list of "normal" URLs now (since all URLs will be "tlsDisabled")
+		cfg.Urls += " " + cfg.TlsDisabledUrls
+		cfg.TlsDisabledUrls = ""
+	}
+
+	command += " " + cfg.Urls + " --proto =http,https,telnet"
+
+	if cfg.TlsDisabledUrls != "" {
+		command += fmt.Sprintf(
+			` --next --insecure --retry %v --retry-connrefused -s -I -m %s -w "%%{stderr}@NV@%%{json}\n" %s --proto =https`,
+			cfg.Retry,
+			cfg.MaxTime,
+			cfg.TlsDisabledUrls,
+		)
+	}
+
+	return command, nil
+
+}
+func (o *Options) NoTLS() bool {
+	noTLS, _ := strconv.ParseBool(o.NoTls)
+	return noTLS
+}

--- a/pkg/data/curlgen/curlgen_test.go
+++ b/pkg/data/curlgen/curlgen_test.go
@@ -1,0 +1,70 @@
+package curlgen
+
+import (
+	"testing"
+)
+
+func TestGenerateString(t *testing.T) {
+
+	tests := []struct {
+		name    string
+		args    *Options
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "Happy Path",
+			args: &Options{
+				CaPath:          "/some/config/path/",
+				ProxyCaPath:     "/some/config/path/",
+				Retry:           3,
+				MaxTime:         "4",
+				NoTls:           "false",
+				Urls:            "http://example.com:80 https://example.org:443",
+				TlsDisabledUrls: "http://example2.com:80 https://example2.org:443",
+			},
+			want:    "curl --capath /some/config/path/ --proxy-capath /some/config/path/ --retry 3 --retry-connrefused -t B -Z -s -I -m 4 -w \"%{stderr}@NV@%{json}\\n\" http://example.com:80 https://example.org:443 --proto =http,https,telnet --next --insecure --retry 3 --retry-connrefused -s -I -m 4 -w \"%{stderr}@NV@%{json}\\n\" http://example2.com:80 https://example2.org:443 --proto =https",
+			wantErr: false,
+		},
+		{
+			name: "NoTls true with tlsDisabledUrls",
+			args: &Options{
+				CaPath:          "/some/config/path/",
+				ProxyCaPath:     "/some/config/path/",
+				Retry:           3,
+				MaxTime:         "4",
+				NoTls:           "true",
+				Urls:            "http://example.com:80 https://example.org:443",
+				TlsDisabledUrls: "http://example2.com:80 https://example2.org:443",
+			},
+			want:    "curl --capath /some/config/path/ --proxy-capath /some/config/path/ --retry 3 --retry-connrefused -t B -Z -s -I -m 4 -w \"%{stderr}@NV@%{json}\\n\" --insecure http://example.com:80 https://example.org:443 http://example2.com:80 https://example2.org:443 --proto =http,https,telnet",
+			wantErr: false,
+		},
+		{
+			name: "NoTls False with No TlsDisabledURLs",
+			args: &Options{
+				CaPath:          "/some/config/path/",
+				ProxyCaPath:     "/some/config/path/",
+				Retry:           3,
+				MaxTime:         "4",
+				NoTls:           "false",
+				Urls:            "http://example.com:80 https://example.org:443",
+				TlsDisabledUrls: "",
+			},
+			want:    "curl --capath /some/config/path/ --proxy-capath /some/config/path/ --retry 3 --retry-connrefused -t B -Z -s -I -m 4 -w \"%{stderr}@NV@%{json}\\n\" http://example.com:80 https://example.org:443 --proto =http,https,telnet",
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GenerateString(tt.args, "@NV@")
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GenerateString() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("GenerateString() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/probes/curl/curl_json_test.go
+++ b/pkg/probes/curl/curl_json_test.go
@@ -1,7 +1,6 @@
 package curl
 
 import (
-	_ "embed"
 	"regexp"
 	"strings"
 	"testing"
@@ -78,7 +77,7 @@ func TestCurlJSONProbe_GetExpandedUserData(t *testing.T) {
 				"URLS":    "http://example.com:80 https://example.org:443",
 				"NOTLS":   "True",
 			},
-			wantRegex: `#cloud-config[\s\S]* -k [\s\S]*http:\/\/example.com:80 https:\/\/example.org:443`,
+			wantRegex: `#cloud-config[\s\S]* --insecure [\s\S]*http:\/\/example.com:80 https:\/\/example.org:443`,
 		},
 		{
 			name: "tlsDisabled URLs provided",
@@ -88,7 +87,7 @@ func TestCurlJSONProbe_GetExpandedUserData(t *testing.T) {
 				"URLS":             "http://example.com:80 https://example.org:443",
 				"TLSDISABLED_URLS": "https://example.net:443",
 			},
-			wantRegex: `#cloud-config[\s\S]*https:\/\/example.org:443[\s\S]*--next -k[\s\S]*https:\/\/example.net:443`,
+			wantRegex: `#cloud-config[\s\S]*https:\/\/example.org:443[\s\S]*--next --insecure[\s\S]*https:\/\/example.net:443`,
 		},
 		{
 			name: "NOTLS and tlsDisabled URLs provided",
@@ -99,7 +98,7 @@ func TestCurlJSONProbe_GetExpandedUserData(t *testing.T) {
 				"URLS":             "http://example.com:80 https://example.org:443",
 				"TLSDISABLED_URLS": "https://example.net:443",
 			},
-			wantRegex: `#cloud-config[\s\S]* -k [\s\S]*http:\/\/example.com:80 https:\/\/example.org:443 https:\/\/example.net:443`,
+			wantRegex: `#cloud-config[\s\S]* --insecure [\s\S]*http:\/\/example.com:80 https:\/\/example.org:443 https:\/\/example.net:443`,
 		},
 		{
 			name:                      "missing variables required by directive",
@@ -143,7 +142,7 @@ func TestCurlJSONProbe_GetExpandedUserData(t *testing.T) {
 				"URLS":    "http://example.com:80 https://example.org:443",
 				"NOTLS":   "maybe?",
 			},
-			wantErr: true,
+			wantRegex: `#cloud-config[\s\S]*http:\/\/example.com:80 https:\/\/example.org:443`,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/probes/curl/systemd-template.sh
+++ b/pkg/probes/curl/systemd-template.sh
@@ -16,7 +16,7 @@ array=(1 2 3 4 27 41 42 43 45)
 if echo ${USERDATA_BEGIN} > /dev/ttyS0 ; then : ; else
     exit 255
 fi
-curl --retry 3 --retry-connrefused -t B -Z -s -I -m ${TIMEOUT} -w "%{stderr}${LINE_PREFIX}%{json}\n" ${CURLOPT} ${URLS} --proto =http,https,telnet ${TLSDISABLED_URLS_RENDERED} 2>/dev/ttyS0
+${CURL_COMMAND} 2>/dev/ttyS0
 ret=$?
 value="\<${ret}\>"
 if [[ " ${array[@]} " =~ $value ]]; then

--- a/pkg/probes/curl/userdata-template.yaml
+++ b/pkg/probes/curl/userdata-template.yaml
@@ -1,12 +1,12 @@
 #cloud-config
-# network-verifier-required-variables=TIMEOUT,DELAY,URLS
+# network-verifier-required-variables=CURL_COMMAND,DELAY
 ${CACERT_RENDERED}
 runcmd:
   - systemctl mask --now serial-getty@ttyS0.service
   - dmesg -D
   - echo "${USERDATA_BEGIN}" >/dev/ttyS0
   - export http_proxy=${HTTP_PROXY} https_proxy=${HTTPS_PROXY} no_proxy="${NO_PROXY}"
-  - curl --capath /etc/pki/tls/certs/ --proxy-capath /etc/pki/tls/certs/ --retry 3 --retry-connrefused -t B -Z -s -I -m ${TIMEOUT} -w "%{stderr}${LINE_PREFIX}%{json}\n" ${CURLOPT} ${URLS} --proto =http,https,telnet ${TLSDISABLED_URLS_RENDERED} 2>/dev/ttyS0
+  - ${CURL_COMMAND} 2>/dev/ttyS0
   - echo "${USERDATA_END}" >/dev/ttyS0
 power_state:
   delay: ${DELAY}

--- a/pkg/verifier/aws/entry_point.go
+++ b/pkg/verifier/aws/entry_point.go
@@ -3,11 +3,12 @@ package awsverifier
 import (
 	"encoding/base64"
 	"fmt"
+	"os"
+	"strconv"
+
 	awsTools "github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2Types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
-	"os"
-	"strconv"
 
 	"github.com/openshift/osd-network-verifier/pkg/data/cloud"
 


### PR DESCRIPTION
- Refactoring
Centralize the logic/template that we use to generate curl commands in the network verifier such that there are not multiple pieces of the codebase that need to be updated each time we need to make a change to the curl command.

Changed the instances in which we use the flag "-k" for its more readable equivalent "--insecure"

## What does this PR do? / Related Issues / Jira
Exports the building of the Curl command used in the network verifier curl probe. into it's own package.
