### PR TITLE
Fix OSD-21112: Add IPv6 security group rules for IPv6-only networks

### DIFF
--- a/pkg/verifier/aws/aws_verifier_test.go
+++ b/pkg/verifier/aws/aws_verifier_test.go
@@ -170,7 +170,7 @@ func TestIpPermissionFromURL(t *testing.T) {
 	tests := []struct {
 		name    string
 		args    args
-		want    *ec2Types.IpPermission
+		want    []ec2Types.IpPermission
 		wantErr bool
 	}{
 		{
@@ -179,14 +179,16 @@ func TestIpPermissionFromURL(t *testing.T) {
 				urlStr:      "http://1.2.3.4:567",
 				description: "test4",
 			},
-			want: &ec2Types.IpPermission{
-				FromPort:   awss.Int32(567),
-				ToPort:     awss.Int32(567),
-				IpProtocol: awss.String("tcp"),
-				IpRanges: []ec2Types.IpRange{
-					{
-						CidrIp:      awss.String("1.2.3.4/32"),
-						Description: awss.String("test4"),
+			want: []ec2Types.IpPermission{
+				{
+					FromPort:   awss.Int32(567),
+					ToPort:     awss.Int32(567),
+					IpProtocol: awss.String("tcp"),
+					IpRanges: []ec2Types.IpRange{
+						{
+							CidrIp:      awss.String("1.2.3.4/32"),
+							Description: awss.String("test4"),
+						},
 					},
 				},
 			},
@@ -197,14 +199,16 @@ func TestIpPermissionFromURL(t *testing.T) {
 				urlStr:      "http://[ff06::c3]:567",
 				description: "test6",
 			},
-			want: &ec2Types.IpPermission{
-				FromPort:   awss.Int32(567),
-				ToPort:     awss.Int32(567),
-				IpProtocol: awss.String("tcp"),
-				Ipv6Ranges: []ec2Types.Ipv6Range{
-					{
-						CidrIpv6:    awss.String("ff06::c3/128"),
-						Description: awss.String("test6"),
+			want: []ec2Types.IpPermission{
+				{
+					FromPort:   awss.Int32(567),
+					ToPort:     awss.Int32(567),
+					IpProtocol: awss.String("tcp"),
+					Ipv6Ranges: []ec2Types.Ipv6Range{
+						{
+							CidrIpv6:    awss.String("ff06::c3/128"),
+							Description: awss.String("test6"),
+						},
 					},
 				},
 			},
@@ -215,14 +219,16 @@ func TestIpPermissionFromURL(t *testing.T) {
 				urlStr:      "https://10.0.8.8",
 				description: "testi",
 			},
-			want: &ec2Types.IpPermission{
-				FromPort:   awss.Int32(443),
-				ToPort:     awss.Int32(443),
-				IpProtocol: awss.String("tcp"),
-				IpRanges: []ec2Types.IpRange{
-					{
-						CidrIp:      awss.String("10.0.8.8/32"),
-						Description: awss.String("testi"),
+			want: []ec2Types.IpPermission{
+				{
+					FromPort:   awss.Int32(443),
+					ToPort:     awss.Int32(443),
+					IpProtocol: awss.String("tcp"),
+					IpRanges: []ec2Types.IpRange{
+						{
+							CidrIp:      awss.String("10.0.8.8/32"),
+							Description: awss.String("testi"),
+						},
 					},
 				},
 			},
@@ -233,14 +239,27 @@ func TestIpPermissionFromURL(t *testing.T) {
 				urlStr:      "https://example.fqdn.test.com",
 				description: "test-fqdn",
 			},
-			want: &ec2Types.IpPermission{
-				FromPort:   awss.Int32(443),
-				ToPort:     awss.Int32(443),
-				IpProtocol: awss.String("tcp"),
-				IpRanges: []ec2Types.IpRange{
-					{
-						CidrIp:      awss.String("0.0.0.0/0"),
-						Description: awss.String("test-fqdn"),
+			want: []ec2Types.IpPermission{
+				{
+					FromPort:   awss.Int32(443),
+					ToPort:     awss.Int32(443),
+					IpProtocol: awss.String("tcp"),
+					IpRanges: []ec2Types.IpRange{
+						{
+							CidrIp:      awss.String("0.0.0.0/0"),
+							Description: awss.String("test-fqdn"),
+						},
+					},
+				},
+				{
+					FromPort:   awss.Int32(443),
+					ToPort:     awss.Int32(443),
+					IpProtocol: awss.String("tcp"),
+					Ipv6Ranges: []ec2Types.Ipv6Range{
+						{
+							CidrIpv6:    awss.String("::/0"),
+							Description: awss.String("test-fqdn"),
+						},
 					},
 				},
 			},
@@ -251,14 +270,27 @@ func TestIpPermissionFromURL(t *testing.T) {
 				urlStr:      "http://example.fqdn.test.com",
 				description: "test-fqdn2",
 			},
-			want: &ec2Types.IpPermission{
-				FromPort:   awss.Int32(80),
-				ToPort:     awss.Int32(80),
-				IpProtocol: awss.String("tcp"),
-				IpRanges: []ec2Types.IpRange{
-					{
-						CidrIp:      awss.String("0.0.0.0/0"),
-						Description: awss.String("test-fqdn2"),
+			want: []ec2Types.IpPermission{
+				{
+					FromPort:   awss.Int32(80),
+					ToPort:     awss.Int32(80),
+					IpProtocol: awss.String("tcp"),
+					IpRanges: []ec2Types.IpRange{
+						{
+							CidrIp:      awss.String("0.0.0.0/0"),
+							Description: awss.String("test-fqdn2"),
+						},
+					},
+				},
+				{
+					FromPort:   awss.Int32(80),
+					ToPort:     awss.Int32(80),
+					IpProtocol: awss.String("tcp"),
+					Ipv6Ranges: []ec2Types.Ipv6Range{
+						{
+							CidrIpv6:    awss.String("::/0"),
+							Description: awss.String("test-fqdn2"),
+						},
 					},
 				},
 			},
@@ -269,14 +301,27 @@ func TestIpPermissionFromURL(t *testing.T) {
 				urlStr:      "http://example.fqdn.test.com:7654",
 				description: "test-fqdn3",
 			},
-			want: &ec2Types.IpPermission{
-				FromPort:   awss.Int32(7654),
-				ToPort:     awss.Int32(7654),
-				IpProtocol: awss.String("tcp"),
-				IpRanges: []ec2Types.IpRange{
-					{
-						CidrIp:      awss.String("0.0.0.0/0"),
-						Description: awss.String("test-fqdn3"),
+			want: []ec2Types.IpPermission{
+				{
+					FromPort:   awss.Int32(7654),
+					ToPort:     awss.Int32(7654),
+					IpProtocol: awss.String("tcp"),
+					IpRanges: []ec2Types.IpRange{
+						{
+							CidrIp:      awss.String("0.0.0.0/0"),
+							Description: awss.String("test-fqdn3"),
+						},
+					},
+				},
+				{
+					FromPort:   awss.Int32(7654),
+					ToPort:     awss.Int32(7654),
+					IpProtocol: awss.String("tcp"),
+					Ipv6Ranges: []ec2Types.Ipv6Range{
+						{
+							CidrIpv6:    awss.String("::/0"),
+							Description: awss.String("test-fqdn3"),
+						},
 					},
 				},
 			},
@@ -444,6 +489,17 @@ func Test_ipPermissionSetFromURLs(t *testing.T) {
 					IpRanges: []ec2Types.IpRange{
 						{
 							CidrIp:      awss.String("0.0.0.0/0"),
+							Description: awss.String("multi-identical test: http://proxy.example.org:567"),
+						},
+					},
+				},
+				{
+					FromPort:   awss.Int32(567),
+					ToPort:     awss.Int32(567),
+					IpProtocol: awss.String("tcp"),
+					Ipv6Ranges: []ec2Types.Ipv6Range{
+						{
+							CidrIpv6:    awss.String("::/0"),
 							Description: awss.String("multi-identical test: http://proxy.example.org:567"),
 						},
 					},


### PR DESCRIPTION
This PR fixes OSD-21112 by adding IPv6 support to the network verifier's security group rules.

## Problem
The network verifier currently only creates IPv4 security group rules (`0.0.0.0/0`) when handling FQDN proxy URLs, causing IPv6-only networks to fail verification.

## Solution
1. **Modified `defaultIpPermissions`**: Split combined IPv4+IPv6 rules into separate IPv4 and IPv6 rules for ports 80, 443, 9997, and 53
2. **Updated `ipPermissionFromURL`**: 
   - Changed return type from `*ec2Types.IpPermission` to `[]ec2Types.IpPermission`
   - For FQDN proxy URLs, now creates both IPv4 (`0.0.0.0/0`) and IPv6 (`::/0`) wildcard rules
3. **Updated `ipPermissionSetFromURLs`**: Modified to handle the new function signature
4. **Fixed tests**: Updated test cases to expect the new dual-rule structure

## Changes
- `pkg/verifier/aws/aws_verifier.go`: Core logic changes
- `pkg/verifier/aws/aws_verifier_test.go`: Updated test expectations

## Testing
- All existing tests pass
- New behavior properly creates both IPv4 and IPv6 rules for FQDN endpoints
- IPv6 rules are correctly deduplicated when they overlap with default rules

Fixes: https://issues.redhat.com/browse/OSD-21112