### PR TITLE
SREP-1449: Use ubi10 base image for --pod-mode

### DIFF
--- a/pkg/verifier/kube/kube_verifier.go
+++ b/pkg/verifier/kube/kube_verifier.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	defaultContainerImage          = "image-registry.openshift-image-registry.svc:5000/openshift/tools"
+	defaultContainerImage          = "registry.access.redhat.com/ubi10/ubi-minimal:10.0"
 	defaultTTLSecondsAfterFinished = int32(600) // 10 minutes
 	defaultActiveDeadlineSeconds   = int32(300) // 5 minutes
 	defaultBackoffLimit            = int32(0)   // We only want to try once


### PR DESCRIPTION
## What does this PR do? / Related Issues / Jira

We have seen lots of odd TLS failures with the tools image bundled with OCP and `curl`. This switches us to use ubi10, which in my testing, resolved all false negatives.

Curl and OpenSSL versions for UBI10
```
[root@1e623027406d /]# curl --version
curl 8.9.1 (aarch64-redhat-linux-gnu) libcurl/8.9.1 OpenSSL/3.2.2 zlib/1.3.1.zlib-ng libidn2/2.3.7 nghttp2/1.64.0
Release-Date: 2024-07-31
Protocols: file ftp ftps http https ipfs ipns
Features: alt-svc AsynchDNS GSS-API HSTS HTTP2 HTTPS-proxy IDN IPv6 Kerberos Largefile libz SPNEGO SSL threadsafe UnixSockets
```

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have tested the functionality against gcp / aws, it doesn't cause any regression
- [x] I have added execution results to the PR's readme

## Reviewer's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] (This needs to be done after technical review) I've run the branch on my local, verified that the functionality is ok

## How to test this PR locally / Special Instructions

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Logs 

Successful runs using this image now:
```
 ./osd-network-verifier egress --pod-mode --region us-east-1
Using egress URL list from https://api.github.com/repos/openshift/osd-network-verifier/contents/pkg/data/egress_lists/aws-classic.yaml?ref=main at SHA 997186fa8fbf863db4b071d246e7bb781bc1e796
Summary:
All tests passed!
Success

󰀵 jbranham  …/osd-network-verifier   change-pod-mode-image-to-ubi10 $  ⎈ hives03ue1   v1.23.6   09:34 
 ./osd-network-verifier egress --pod-mode --region us-east-1
Using egress URL list from https://api.github.com/repos/openshift/osd-network-verifier/contents/pkg/data/egress_lists/aws-classic.yaml?ref=main at SHA 997186fa8fbf863db4b071d246e7bb781bc1e796
Summary:
All tests passed!
Success

󰀵 jbranham  …/osd-network-verifier   change-pod-mode-image-to-ubi10 $  ⎈ hives03ue1   v1.23.6   09:35 
 ./osd-network-verifier egress --pod-mode --region us-east-1
Using egress URL list from https://api.github.com/repos/openshift/osd-network-verifier/contents/pkg/data/egress_lists/aws-classic.yaml?ref=main at SHA 997186fa8fbf863db4b071d246e7bb781bc1e796
Summary:
All tests passed!
Success
```