### PR TITLE
SREP-1453: Handle FailureTarget status for Jobs

### DIFF
--- a/pkg/clients/kube/kube.go
+++ b/pkg/clients/kube/kube.go
@@ -127,7 +127,7 @@ func (c *Client) WaitForJobCompletion(ctx context.Context, jobName string) error
 			if jobStatus == batchv1.JobComplete || jobStatus == batchv1.JobSuccessCriteriaMet {
 				return nil
 			}
-			if jobStatus == batchv1.JobFailed {
+			if jobStatus == batchv1.JobFailed || jobStatus == batchv1.JobFailureTarget {
 				return fmt.Errorf("job %s failed", jobName)
 			}
 		}

--- a/pkg/verifier/kube/kube_verifier.go
+++ b/pkg/verifier/kube/kube_verifier.go
@@ -29,7 +29,7 @@ import (
 const (
 	defaultContainerImage          = "registry.access.redhat.com/ubi10/ubi-minimal:10.0"
 	defaultTTLSecondsAfterFinished = int32(600) // 10 minutes
-	defaultActiveDeadlineSeconds   = int32(300) // 5 minutes
+	defaultActiveDeadlineSeconds   = int32(180) // 3 minutes
 	defaultBackoffLimit            = int32(0)   // We only want to try once
 )
 


### PR DESCRIPTION
## What does this PR do? / Related Issues / Jira
When the verifier Job fails to schedule a Pod due to `ImagePullBackoff`, the watcher would hang indefinitely until you exited.

This was primarily due to the `FailureTarget` status that shows up in the slice of status conditions. We need to detect this as a possible failure mode as well, since it shows up first.

I also lowered the deadline to 3min, since we really expect this Pod to complete quickly.

I tested this by using a bogus image.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have tested the functionality against gcp / aws, it doesn't cause any regression
- [x] I have added execution results to the PR's readme

## Reviewer's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] (This needs to be done after technical review) I've run the branch on my local, verified that the functionality is ok

## How to test this PR locally / Special Instructions

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Logs 

```
 ./osd-network-verifier egress --pod-mode --region us-east-1
Using egress URL list from https://api.github.com/repos/openshift/osd-network-verifier/contents/pkg/data/egress_lists/aws-classic.yaml?ref=main at SHA 997186fa8fbf863db4b071d246e7bb781bc1e796
Summary:
printing out failures:
printing out exceptions preventing the verifier from running the specific test:
printing out errors faced during the execution:
 - network verifier error: network verifier error: job osd-network-verifier-job-1754599312 failed or timed out: job osd-network-verifier-job-1754599312 failed

Failure!
```
