### PR TITLE
Updated mitmproxy to 12.1.2 in explicitly proxied VPC Terraform examples

### DIFF
--- a/examples/aws/terraform/vpc-proxied-explicit/assets/Caddyfile.tpl
+++ b/examples/aws/terraform/vpc-proxied-explicit/assets/Caddyfile.tpl
@@ -20,6 +20,7 @@
 			header_up Host "127.0.0.1:8081"
 			header_up Origin "http://127.0.0.1:8081"
 			header_up -X-Frame-Options
+			header_up Authorization "Bearer ${proxy_webui_password}" 
 		}
 	}
 }

--- a/examples/aws/terraform/vpc-proxied-explicit/assets/mitmproxy.service.tpl
+++ b/examples/aws/terraform/vpc-proxied-explicit/assets/mitmproxy.service.tpl
@@ -6,7 +6,7 @@ Wants=network.target iptables.service
 [Service]
 Type=simple
 User=root
-ExecStart=/usr/bin/mitmweb --web-port=8081 --web-host=0.0.0.0 --no-web-open-browser --showhost
+ExecStart=/usr/bin/mitmweb --web-port=8081 --web-host=0.0.0.0 --no-web-open-browser --showhost --set web_password="${proxy_webui_password}"
 Restart=always
 
 [Install]

--- a/examples/aws/terraform/vpc-proxied-explicit/assets/userdata.yaml.tpl
+++ b/examples/aws/terraform/vpc-proxied-explicit/assets/userdata.yaml.tpl
@@ -34,7 +34,7 @@ write_files:
   permissions: '0644'
 runcmd:
 - sysctl -p /etc/sysctl.d/mitmproxy.conf
-- curl -s https://downloads.mitmproxy.org/10.3.0/mitmproxy-10.3.0-linux-x86_64.tar.gz -o - | tar -C /usr/bin/ -xzf -
+- curl -s https://downloads.mitmproxy.org/12.1.2/mitmproxy-12.1.2-linux-x86_64.tar.gz -o - | tar -C /usr/bin/ -xzf -
 - iptables -F
 - iptables -X
 - iptables -t nat -F


### PR DESCRIPTION
The terraform scripts in our examples/aws/terraform directory have a dependency on a proxy tool called [mitmproxy](https://www.mitmproxy.org/). This PR updates that dependency to the latest version in order to include the latest security and bug fixes. This PR also makes changes to the Caddyfile necessary for addressing a breaking bugfix in mitmproxy. Finally, it also adds an ignore_tags directive so that running `terraform apply` again after installing a ROSA HCP machinepool into a generated subnet doesn't cause Terraform to try to remove the subnet tags added by the installer