### PR TITLE
Enhancement: Add a ticker to check job completion as a fallback

### DIFF
--- a/pkg/clients/kube/kube.go
+++ b/pkg/clients/kube/kube.go
@@ -148,9 +148,13 @@ func (c *Client) WaitForJobCompletion(ctx context.Context, jobName string) error
 			if err := checkJobCompletion(currentJob); err != errJobIncomplete {
 				return err
 			}
-		case event := <-watcher.ResultChan():
-			job, ok := event.Object.(*batchv1.Job)
+		case event, ok := <-watcher.ResultChan():
 			if !ok {
+				// Watch channel closed, fall back to polling
+				continue
+			}
+			job, isJob := event.Object.(*batchv1.Job)
+			if !isJob {
 				continue
 			}
 			if err := checkJobCompletion(job); err != errJobIncomplete {

--- a/pkg/clients/kube/kube.go
+++ b/pkg/clients/kube/kube.go
@@ -104,6 +104,9 @@ func (c *Client) GetJobLogs(ctx context.Context, jobName string) (string, error)
 	return string(logs), nil
 }
 
+// errJobIncomplete is a sentinel error to indicate a job is still in progress
+var errJobIncomplete = fmt.Errorf("job incomplete")
+
 // WaitForJobCompletion waits for a job to complete (succeed or fail). It's context-aware,
 // so set ctx to something like `context.WithTimeout(ctx, 10*time.Second)` to set a timeout.
 func (c *Client) WaitForJobCompletion(ctx context.Context, jobName string) error {
@@ -113,22 +116,45 @@ func (c *Client) WaitForJobCompletion(ctx context.Context, jobName string) error
 	}
 	defer watcher.Stop()
 
+	// Add a ticker to periodically check job status directly as a fallback
+	// This handles cases where watch events are delayed, missing, or incomplete
+	ticker := time.NewTicker(10 * time.Second)
+	defer ticker.Stop()
+
+	checkJobCompletion := func(job *batchv1.Job) error {
+		// Rely on Kubernetes' own logic via job conditions
+		jobStatus := getJobStatus(job)
+		if jobStatus == batchv1.JobComplete || jobStatus == batchv1.JobSuccessCriteriaMet {
+			return nil
+		}
+		if jobStatus == batchv1.JobFailed || jobStatus == batchv1.JobFailureTarget {
+			return fmt.Errorf("job %s failed", jobName)
+		}
+
+		// Job not yet complete
+		return errJobIncomplete
+	}
+
 	for {
 		select {
 		case <-ctx.Done():
 			return fmt.Errorf("context cancelled while waiting for job %s to complete", jobName)
+		case <-ticker.C:
+			// Polling fallback: directly query job status
+			currentJob, err := c.GetJob(ctx, jobName)
+			if err != nil {
+				continue
+			}
+			if err := checkJobCompletion(currentJob); err != errJobIncomplete {
+				return err
+			}
 		case event := <-watcher.ResultChan():
 			job, ok := event.Object.(*batchv1.Job)
 			if !ok {
 				continue
 			}
-
-			jobStatus := getJobStatus(job)
-			if jobStatus == batchv1.JobComplete || jobStatus == batchv1.JobSuccessCriteriaMet {
-				return nil
-			}
-			if jobStatus == batchv1.JobFailed || jobStatus == batchv1.JobFailureTarget {
-				return fmt.Errorf("job %s failed", jobName)
+			if err := checkJobCompletion(job); err != errJobIncomplete {
+				return err
 			}
 		}
 	}

--- a/pkg/clients/kube/kube_test.go
+++ b/pkg/clients/kube/kube_test.go
@@ -3,7 +3,9 @@ package kube
 import (
 	"context"
 	"reflect"
+	"strings"
 	"testing"
+	"time"
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -307,5 +309,123 @@ func getMockedJob(name string) *batchv1.Job {
 			Namespace: testNamespace,
 			Name:      name,
 		},
+	}
+}
+
+func TestClient_WaitForJobCompletion(t *testing.T) {
+	tests := []struct {
+		name           string
+		jobName        string
+		setupJob       func(*fak8s.Clientset) error
+		wantErr        bool
+		errContains    string
+		timeoutSeconds int
+	}{
+		{
+			name:    "job completes with JobComplete condition",
+			jobName: "test-job-condition-complete",
+			setupJob: func(clientset *fak8s.Clientset) error {
+				job := getMockedJob("test-job-condition-complete")
+				job.Status.Conditions = []batchv1.JobCondition{
+					{
+						Type:   batchv1.JobComplete,
+						Status: corev1.ConditionTrue,
+					},
+				}
+				_, err := clientset.BatchV1().Jobs(testNamespace).Create(context.Background(), job, metav1.CreateOptions{})
+				return err
+			},
+			wantErr:        false,
+			timeoutSeconds: 15,
+		},
+		{
+			name:    "job fails with JobFailed condition",
+			jobName: "test-job-condition-failed",
+			setupJob: func(clientset *fak8s.Clientset) error {
+				job := getMockedJob("test-job-condition-failed")
+				job.Status.Conditions = []batchv1.JobCondition{
+					{
+						Type:   batchv1.JobFailed,
+						Status: corev1.ConditionTrue,
+					},
+				}
+				_, err := clientset.BatchV1().Jobs(testNamespace).Create(context.Background(), job, metav1.CreateOptions{})
+				return err
+			},
+			wantErr:        true,
+			errContains:    "failed",
+			timeoutSeconds: 15,
+		},
+		{
+			name:    "job completes with JobSuccessCriteriaMet condition",
+			jobName: "test-job-success-criteria-met",
+			setupJob: func(clientset *fak8s.Clientset) error {
+				job := getMockedJob("test-job-success-criteria-met")
+				job.Status.Conditions = []batchv1.JobCondition{
+					{
+						Type:   batchv1.JobSuccessCriteriaMet,
+						Status: corev1.ConditionTrue,
+					},
+				}
+				_, err := clientset.BatchV1().Jobs(testNamespace).Create(context.Background(), job, metav1.CreateOptions{})
+				return err
+			},
+			wantErr:        false,
+			timeoutSeconds: 15,
+		},
+		{
+			name:    "job fails with JobFailureTarget condition",
+			jobName: "test-job-failure-target",
+			setupJob: func(clientset *fak8s.Clientset) error {
+				job := getMockedJob("test-job-failure-target")
+				job.Status.Conditions = []batchv1.JobCondition{
+					{
+						Type:   batchv1.JobFailureTarget,
+						Status: corev1.ConditionTrue,
+					},
+				}
+				_, err := clientset.BatchV1().Jobs(testNamespace).Create(context.Background(), job, metav1.CreateOptions{})
+				return err
+			},
+			wantErr:        true,
+			errContains:    "failed",
+			timeoutSeconds: 15,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a new mock clientset for each test
+			mockedClientset := fak8s.NewClientset()
+			setupJobMockingReactors(mockedClientset)
+
+			// Setup the job
+			if err := tt.setupJob(mockedClientset); err != nil {
+				t.Fatalf("Failed to setup job: %v", err)
+			}
+
+			c := &Client{
+				clientset: mockedClientset,
+				namespace: testNamespace,
+			}
+
+			// Create context with timeout
+			ctx, cancel := context.WithTimeout(context.Background(), time.Duration(tt.timeoutSeconds)*time.Second)
+			defer cancel()
+
+			err := c.WaitForJobCompletion(ctx, tt.jobName)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("WaitForJobCompletion() expected error but got nil")
+				} else if tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("WaitForJobCompletion() error = %v, want error containing %v", err, tt.errContains)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("WaitForJobCompletion() unexpected error = %v", err)
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
<!-- Type of change
Please mark this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement/Feature
- Refactoring
- Tests
- Configuration
- Docs
-->

Enhancement

## What does this PR do? / Related Issues / Jira

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

Assisted by Claude Code.

This PR adds a ticker to check the job completion.

When using `osdctl network verify-egress` with pod mode, it hangs when waiting for job completion:
```
osdctl network verify-egress -C xxxxxx --reason "xxxxxx"

2026/05/14 14:17:07 Cluster is HCP - forcing pod mode.
2026/05/14 14:17:07 Preparing to run pod-based network verification in namespace openshift-network-diagnostics.
2026/05/14 14:17:10 Pod mode using elevated backplane credentials (backplane-cluster-admin) for cluster: xxxxxx
2026/05/14 14:17:10 Pod mode initialized with namespace: openshift-network-diagnostics
2026/05/14 14:17:10 Detected AWS region from OCM: us-east-2
Using egress URL list from https://api.github.com/repos/openshift/osd-network-verifier/contents/pkg/data/egress_lists/aws-hcp.yaml?ref=main at SHA 1cb7c15e951908f44d5ff3b3589ec763cea917c9
^C

(hangs here)
```
From the cluster, I can see the job has already completed.

It could be some issues that lead to the `watch` broken, and the `WaitForJobCompletion` keeps in a loop.

This PR adds a ticker to get the job status every 10s, as a fallback.

After this change, the verify-egress can succeed:
```
osdctl network verify-egress -C xxxxxxx --reason "xxxxxx"
2026/05/14 15:36:45 Cluster is HCP - forcing pod mode.
2026/05/14 15:36:45 Preparing to run pod-based network verification in namespace openshift-network-diagnostics.
2026/05/14 15:36:49 Pod mode using elevated backplane credentials (backplane-cluster-admin) for cluster: xxxxxx
2026/05/14 15:36:49 Pod mode initialized with namespace: openshift-network-diagnostics
2026/05/14 15:36:49 Detected AWS region from OCM: us-east-2
Using egress URL list from https://api.github.com/repos/openshift/osd-network-verifier/contents/pkg/data/egress_lists/aws-hcp.yaml?ref=main at SHA 1cb7c15e951908f44d5ff3b3589ec763cea917c9
Summary:
All tests passed!
```

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have tested the functionality against gcp / aws, it doesn't cause any regression
- [x] I have added execution results to the PR's readme

## Reviewer's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] (This needs to be done after technical review) I've run the branch on my local, verified that the functionality is ok

## How to test this PR locally / Special Instructions

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Logs 

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved job completion monitoring by combining event watches with periodic polling and more robust handling of watch interruptions, reducing false positives/negatives and improving reliability of status detection.
* **Tests**
  * Added unit tests covering various job completion and failure scenarios, including timeout behavior, to validate the waiting logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->